### PR TITLE
Stop putting the session info (all channels of all participants) into…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ venv/
 .vs/
 builds2024/
 .conan_venv/
+builds24/
+buildServer/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X version to ta
 
 project(JammerNetz)
 
+OPTION(BUILD_JAMMERNETZ_CLIENT "Option to turn off the client build" ON)
+
 # Since we also build MacOS, we need C++ 17. Which is not a bad thing.
 # JUCE 8 seems to force us to C++ 20 now!
 set(CMAKE_CXX_STANDARD 20)
@@ -75,9 +77,11 @@ elseif(UNIX)
 	find_package(OpenGL)
 
 	# These calls create special `PkgConfig::<MODULE>` variables
-	pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
-	pkg_check_modules(GLEW REQUIRED IMPORTED_TARGET glew)
-	pkg_check_modules(WEBKIT REQUIRED IMPORTED_TARGET webkit2gtk-4.1)
+	if(BUILD_JAMMERNETZ_CLIENT)
+		pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+		pkg_check_modules(GLEW REQUIRED IMPORTED_TARGET glew)
+		pkg_check_modules(WEBKIT REQUIRED IMPORTED_TARGET webkit2gtk-4.1)
+	endif()
 endif()
 
 
@@ -111,12 +115,17 @@ mark_as_advanced(
 
 # Define the list of link libraries required on Linux linking with JUCE, this must be used by any executable / module to run standalone
 if(UNIX AND NOT APPLE)
-	set(LINUX_JUCE_LINK_LIBRARIES
+	if(BUILD_JAMMERNETZ_CLIENT)
+		set(LINUX_UI_LIBRARIES
 		PkgConfig::WEBKIT
 		PkgConfig::GTK
 		PkgConfig::GLEW
+		)
+	endif()
+	set(LINUX_JUCE_LINK_LIBRARIES
 		Xext
 		X11
+		${LINUX_UI_LIBRARIES}
 		pthread
 		${CMAKE_DL_LIBS}
 		freetype
@@ -133,13 +142,22 @@ add_subdirectory("third_party/JUCE" EXCLUDE_FROM_ALL)
 
 # Build a static library from juce
 add_library(juce-static STATIC)
+if(BUILD_JAMMERNETZ_CLIENT)
+	set(ADDITIONAL_JUCE_MODULES
+		juce::juce_graphics
+		juce::juce_gui_basics
+		juce::juce_gui_extra
+		juce::juce_opengl
+		juce::juce_video
+	)
+endif()
 target_link_libraries(juce-static
 	PRIVATE
 	    juce::juce_audio_basics juce::juce_audio_devices juce::juce_audio_formats
 	    juce::juce_audio_processors juce::juce_audio_utils juce::juce_core
 	    juce::juce_cryptography juce::juce_data_structures juce::juce_dsp
-	    juce::juce_events juce::juce_graphics juce::juce_gui_basics
-	    juce::juce_gui_extra juce::juce_opengl juce::juce_video
+	    juce::juce_events
+		${ADDITIONAL_JUCE_MODULES}
 		${LINUX_JUCE_LINK_LIBRARIES}
 	PUBLIC
 		juce::juce_recommended_config_flags
@@ -170,10 +188,8 @@ target_compile_definitions(juce-static
 target_include_directories(juce-static
 	INTERFACE
 		$<TARGET_PROPERTY:juce-static,INCLUDE_DIRECTORIES>
-if (WIN32)
 	PRIVATE
 		"${ASIO_SDK_DIRECTORY}"
-endif()
 		)
 
 set_target_properties(juce-static PROPERTIES
@@ -194,21 +210,26 @@ if(WIN32)
 endif()
 
 # Add subdirectories
-add_subdirectory("third_party/JUCE-user-modules")
 add_subdirectory("third_party/json")
 add_subdirectory("third_party/fmt")
 add_subdirectory("third_party/spdlog")
 add_subdirectory("modules/juce-utils")
-add_subdirectory("modules/juce-widgets")
+if(BUILD_JAMMERNETZ_CLIENT)
+	add_subdirectory("third_party/JUCE-user-modules")
+	add_subdirectory("modules/juce-widgets")
+endif()
 add_subdirectory("modules/MidiKraft")
 message(${CMAKE_MODULE_PATH})
 add_subdirectory("third_party/oneTBB" EXCLUDE_FROM_ALL)
 add_subdirectory("common")
 add_subdirectory("Server")
+
+if(BUILD_JAMMERNETZ_CLIENT)
 add_subdirectory("Client")
 
 # The client installer now contains the server as well for local testing - make sure to always build the server
 add_dependencies(JammerNetzClient JammerNetzServer)
+endif()
 
 # For Windows, we additionally build a little test program to check if ASIO initialization works.
 if(WIN32)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -86,6 +86,7 @@ set(UICOMPONENT_FILES
 	Source/ClientConfig.h
 	Source/DeviceSelector.cpp
 	Source/DeviceSelector.h
+	Source/IncludeFFMeters.h
 	Source/MidiDeviceSelector.cpp
 	Source/MidiDeviceSelector.h
 	Source/RecordingInfo.cpp

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -159,7 +159,7 @@ if (MSVC)
 else()
     # lots of warnings and all warnings as errors
     #target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -pedantic -Werror)
-    target_compile_options(JammerNetzClient PRIVATE -Wno-unknown-pragmas)
+    target_compile_options(JammerNetzClient PRIVATE -Werror -Wno-unknown-pragmas)
 endif()
 
 IF(WIN32)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -159,7 +159,7 @@ if (MSVC)
     target_compile_options(JammerNetzClient PRIVATE /W4 /WX)
 else()
     # lots of warnings and all warnings as errors
-    target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -pedantic -Werror -Wno-unknown-pragmas)
+    target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -Werror -Wno-unknown-pragmas)
 endif()
 
 IF(WIN32)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -158,8 +158,7 @@ if (MSVC)
     target_compile_options(JammerNetzClient PRIVATE /W4 /WX)
 else()
     # lots of warnings and all warnings as errors
-    #target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -pedantic -Werror)
-    target_compile_options(JammerNetzClient PRIVATE -Werror -Wno-unknown-pragmas)
+    target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -pedantic -Werror -Wno-unknown-pragmas)
 endif()
 
 IF(WIN32)

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -159,6 +159,7 @@ if (MSVC)
 else()
     # lots of warnings and all warnings as errors
     #target_compile_options(JammerNetzClient PRIVATE -Wall -Wextra -pedantic -Werror)
+    target_compile_options(JammerNetzClient PRIVATE -Wno-unknown-pragmas)
 endif()
 
 IF(WIN32)

--- a/Client/Source/AudioCallback.cpp
+++ b/Client/Source/AudioCallback.cpp
@@ -26,7 +26,7 @@ AudioCallback::AudioCallback() : jammerService_([this](std::shared_ptr < JammerN
 	// Where to record to?
 	uploadRecorder_ = std::make_shared<Recorder>(Settings::instance().getSessionStorageDir(), "LocalRecording", RecordingType::WAV);
 	masterRecorder_ = std::make_shared<Recorder>(Settings::instance().getSessionStorageDir(), "MasterRecording", RecordingType::FLAC);
-	masterRecorder_->setChannelInfo(SAMPLE_RATE, JammerNetzChannelSetup(false, { JammerNetzChannelTarget::Left, JammerNetzChannelTarget::Right }));
+	masterRecorder_->setChannelInfo(SAMPLE_RATE, JammerNetzChannelSetup(false, { JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left), JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right) }));
 	//midiRecorder_ = std::make_unique<MidiRecorder>(deviceManager);
 
 	// We might want to share a score sheet or similar

--- a/Client/Source/AudioCallback.cpp
+++ b/Client/Source/AudioCallback.cpp
@@ -15,8 +15,15 @@
 
 #include "Logger.h"
 
-AudioCallback::AudioCallback() : jammerService_([this](std::shared_ptr < JammerNetzAudioData> buffer) { playBuffer_.push(buffer); }), playBuffer_("server"), masterVolume_(1.0), monitorBalance_(0.0),
-    channelSetup_(false), clientBpm_(0.0f), midiSignalToGenerate_(MidiSignal_None), midiSignalToSend_(MidiSignal_None)
+AudioCallback::AudioCallback() :
+    jammerService_([this](std::shared_ptr < JammerNetzAudioData> buffer) { playBuffer_.push(buffer); })
+    , playBuffer_("server")
+    , masterVolume_(1.0)
+    , monitorBalance_(0.0)
+    , clientBpm_(0.0f)
+    , channelSetup_(false)
+    , midiSignalToSend_(MidiSignal_None)
+    , midiSignalToGenerate_(MidiSignal_None)
 {
 	isPlaying_ = false;
 	minPlayoutBufferLength_ = CLIENT_PLAYOUT_JITTER_BUFFER;
@@ -37,10 +44,10 @@ AudioCallback::AudioCallback() : jammerService_([this](std::shared_ptr < JammerN
 
 	// Setup listeners
 	listeners_.push_back(std::make_unique<ValueListener>(Data::instance().get().getPropertyAsValue(VALUE_MIN_PLAYOUT_BUFFER, nullptr), [this](Value& newValue) {
-		minPlayoutBufferLength_ = (int) newValue.getValue();
+		minPlayoutBufferLength_ = (uint64) newValue.getValue().operator long long();
 	}));
 	listeners_.push_back(std::make_unique<ValueListener>(Data::instance().get().getPropertyAsValue(VALUE_MAX_PLAYOUT_BUFFER, nullptr), [this](Value& newValue) {
-		maxPlayoutBufferLength_ = (int)newValue.getValue();
+		maxPlayoutBufferLength_ = (uint64)newValue.getValue().operator long long();
 	}));
 	auto mixer = Data::instance().get().getOrCreateChildWithName(VALUE_MIXER, nullptr);
 	auto outputController = mixer.getOrCreateChildWithName(VALUE_MASTER_OUTPUT, nullptr);
@@ -123,7 +130,7 @@ void AudioCallback::measureSamplesPerTime(PlayoutQualityInfo &qualityInfo, int n
 }
 
 // https://dsp.stackexchange.com/questions/14754/equal-power-crossfade
-std::pair<double, double> calcMonitorGain() {
+static std::pair<double, double> calcMonitorGain() {
 	auto mixer = Data::instance().get().getChildWithName(VALUE_MIXER);
 	double t = mixer.getProperty(VALUE_MONITOR_BALANCE);
 
@@ -140,7 +147,7 @@ void AudioCallback::calcLocalMonitoring(std::shared_ptr<AudioBuffer<float>> inpu
 		auto [monitorVolume, _] = calcMonitorGain();
 		// Apply gain to our channels and do a stereo mixdown
 		jassert(inputBuffer->getNumSamples() == outputBuffer.getNumSamples());
-		for (int channel = 0; channel < inputBuffer->getNumChannels(); channel++) {
+		for (size_t channel = 0; channel < (size_t) inputBuffer->getNumChannels(); channel++) {
 			const JammerNetzSingleChannelSetup& setup = channelSetup_.channels[channel];
 			float input_volume = (float) (setup.volume * monitorVolume * masterVolume_);
 			switch (setup.target) {
@@ -150,13 +157,13 @@ void AudioCallback::calcLocalMonitoring(std::shared_ptr<AudioBuffer<float>> inpu
 			case Left:
 				// This is a left channel, going into the left.
 				if (outputBuffer.getNumChannels() > 0) {
-					outputBuffer.addFrom(0, 0, *inputBuffer, channel, 0, inputBuffer->getNumSamples(), input_volume);
+					outputBuffer.addFrom(0, 0, *inputBuffer, (int) channel, 0, inputBuffer->getNumSamples(), input_volume);
 				}
 				break;
 			case Right:
 				// And the same for the right channel
 				if (outputBuffer.getNumChannels() > 1) {
-					outputBuffer.addFrom(1, 0, *inputBuffer, channel, 0, inputBuffer->getNumSamples(), input_volume);
+					outputBuffer.addFrom(1, 0, *inputBuffer, (int) channel, 0, inputBuffer->getNumSamples(), input_volume);
 				}
 				break;
 			case SendLeft:
@@ -166,10 +173,10 @@ void AudioCallback::calcLocalMonitoring(std::shared_ptr<AudioBuffer<float>> inpu
 				break;
 			case Mono:
 				if (outputBuffer.getNumChannels() > 0) {
-					outputBuffer.addFrom(0, 0, *inputBuffer, channel, 0, inputBuffer->getNumSamples(), input_volume);
+					outputBuffer.addFrom(0, 0, *inputBuffer, (int) channel, 0, inputBuffer->getNumSamples(), input_volume);
 				}
 				if (outputBuffer.getNumChannels() > 1) {
-					outputBuffer.addFrom(1, 0, *inputBuffer, channel, 0, inputBuffer->getNumSamples(), input_volume);
+					outputBuffer.addFrom(1, 0, *inputBuffer, (int) channel, 0, inputBuffer->getNumSamples(), input_volume);
 				}
 				break;
 			}
@@ -177,17 +184,17 @@ void AudioCallback::calcLocalMonitoring(std::shared_ptr<AudioBuffer<float>> inpu
 	}
 }
 
-uint8 sysexMsb(uint16 in)
+static uint8 sysexMsb(uint16 in)
 {
 	return (uint8)(in >> 7);
 }
 
-uint8 sysexLsb(uint16 in)
+static uint8 sysexLsb(uint16 in)
 {
 	return (uint8)(in & 0x7f);
 }
 
-MidiMessage createBossRC300ClockMessage(double bpm, MidiSignal additionalSignal)
+static MidiMessage createBossRC300ClockMessage(double bpm, MidiSignal additionalSignal)
 {
 	// Boss RC-300 loop pedal is infamous for not being able to slave to MIDI clock. Let's try with tailored sysex messages then
 	// See https://www.vguitarforums.com/smf/index.php?topic=7678.50 "RC300- Here's how to slave the RC-300's Tempo to (some) external sources"
@@ -225,7 +232,7 @@ MidiMessage createBossRC300ClockMessage(double bpm, MidiSignal additionalSignal)
 	return MidiMessage::createSysExMessage(rc300.data(), (int) rc300.size());
 }
 
-std::vector<MidiMessage> createMidiBeatMessage(double bpm, std::optional<MidiSignal> additionalSignal, bool includeBossRC300)
+static std::vector<MidiMessage> createMidiBeatMessage(double bpm, std::optional<MidiSignal> additionalSignal, bool includeBossRC300)
 {
 	// For every Midi "Beat" we create a clock message (0xf8)
 	std::vector<MidiMessage> result;
@@ -292,10 +299,10 @@ void AudioCallback::audioDeviceIOCallbackWithContext(const float* const* inputCh
 			meterSource_.measureBlock(*audioBuffer);
 
 			// Send the MAG, RMS values and the pitch to the server, which will forward it to the other clients so they can show my levels even if they have only the mixed audio
-			for (int c = 0; c < numInputChannels; c++) {
+			for (size_t c = 0; c < (size_t) numInputChannels; c++) {
 				if (c < channelSetup_.channels.size()) {
-					channelSetup_.channels[c].mag = meterSource_.getMaxLevel(c);
-					channelSetup_.channels[c].rms = meterSource_.getRMSLevel(c);
+					channelSetup_.channels[c].mag = meterSource_.getMaxLevel((int) c);
+					channelSetup_.channels[c].rms = meterSource_.getRMSLevel((int) c);
 					channelSetup_.channels[c].pitch = tuner_->getPitch(c);
 				}
 				else {
@@ -535,12 +542,12 @@ double AudioCallback::currentRTT()
 	return jammerService_.receiver()->currentRTT();
 }
 
-float AudioCallback::channelPitch(int channel) const
+float AudioCallback::channelPitch(size_t channel) const
 {
 	return tuner_->getPitch(channel);
 }
 
-float AudioCallback::sessionPitch(int channel) {
+float AudioCallback::sessionPitch(size_t channel) {
 	auto setup = getSessionSetup();
 	if (channel < setup.channels.size())
 		return setup.channels[channel].pitch;

--- a/Client/Source/AudioCallback.h
+++ b/Client/Source/AudioCallback.h
@@ -79,7 +79,7 @@ private:
 class AudioCallback : public AudioIODeviceCallback {
 public:
 	AudioCallback();
-	virtual ~AudioCallback();
+	virtual ~AudioCallback() override;
 
 	void shutdown();
 
@@ -87,7 +87,7 @@ public:
 	void setMidiSignalToSend(MidiSignal signal);
 
 	virtual void audioDeviceIOCallbackWithContext(const float* const* inputChannelData, int numInputChannels, float* const* outputChannelData, int numOutputChannels,
-	    int numSamples, const AudioIODeviceCallbackContext& context);
+	    int numSamples, const AudioIODeviceCallbackContext& context) override;
 	virtual void audioDeviceAboutToStart(AudioIODevice* device) override;
 	virtual void audioDeviceStopped() override;
 
@@ -109,8 +109,8 @@ public:
 	std::string currentReceptionQuality() const;
 	bool isReceivingData();
 	double currentRTT();
-	float channelPitch(int channel) const;
-	float sessionPitch(int channel);
+	float channelPitch(size_t channel) const;
+	float sessionPitch(size_t channel);
 
 	std::shared_ptr<Recorder> getMasterRecorder() const;
 	std::shared_ptr<Recorder> getLocalRecorder() const;

--- a/Client/Source/AudioService.cpp
+++ b/Client/Source/AudioService.cpp
@@ -49,7 +49,7 @@ void AudioService::refreshChannelSetup(std::shared_ptr<ChannelSetup> setup)
 	JammerNetzChannelSetup channelSetup(isLocalMonitoring);
 
 	if (setup) {
-		for (int i = 0; i < setup->activeChannelIndices.size(); i++) {
+		for (size_t i = 0; i < setup->activeChannelIndices.size(); i++) {
 			String inputController = "Input" + String(i);
 			auto controllerData = mixer.getChildWithName(inputController);
 			jassert(controllerData.isValid());
@@ -146,12 +146,12 @@ int AudioService::currentPacketSize()
 	return callback_.currentPacketSize();
 }
 
-float AudioService::channelPitch(int channel) const
+float AudioService::channelPitch(size_t channel) const
 {
 	return callback_.channelPitch(channel);
 }
 
-float AudioService::sessionPitch(int channel)
+float AudioService::sessionPitch(size_t channel)
 {
 	return callback_.sessionPitch(channel);
 }
@@ -225,7 +225,7 @@ std::shared_ptr<ChannelSetup> AudioService::getSetup(ValueTree data) const
 	return channelSetup;
 }
 
-BigInteger makeChannelMask(std::vector<int> const& indices) {
+static BigInteger makeChannelMask(std::vector<int> const& indices) {
 	BigInteger inputChannelMask;
 	for (int activeChannelIndex : indices) {
 		inputChannelMask.setBit(activeChannelIndex);

--- a/Client/Source/AudioService.h
+++ b/Client/Source/AudioService.h
@@ -23,7 +23,7 @@ struct ChannelSetup {
 class AudioService : private ValueTree::Listener {
 public:
 	AudioService();
-	~AudioService();
+	virtual ~AudioService() override;
 
 	void shutdown(); // Controlled stop
 
@@ -48,8 +48,8 @@ public:
 	std::string currentReceptionQuality() const;
 	int currentPacketSize();
 
-	float channelPitch(int channel) const;
-	float sessionPitch(int channel);
+	float channelPitch(size_t channel) const;
+	float sessionPitch(size_t channel);
 
 	FFAU::LevelMeterSource* getInputMeterSource();
 	FFAU::LevelMeterSource* getOutputMeterSource();

--- a/Client/Source/BPMDisplay.cpp
+++ b/Client/Source/BPMDisplay.cpp
@@ -8,7 +8,7 @@
 
 class BPMTimer : public Timer {
 public:
-	BPMTimer(Label &label, std::weak_ptr<MidiClocker> clocker) : label_(label), clocker_(clocker) {};
+	BPMTimer(Label &label, std::weak_ptr<MidiClocker> clocker) : label_(label), clocker_(clocker) {}
 
 	virtual void timerCallback() override
 	{

--- a/Client/Source/ChannelController.cpp
+++ b/Client/Source/ChannelController.cpp
@@ -13,8 +13,13 @@
 
 ChannelController::ChannelController(String const &name, String const &id,
 	bool hasVolume /*= true*/, bool hasTarget /*= true*/, bool hasPitch /* = false */) :
-		id_(id), levelMeter_(name == "Master" ? FFAU::LevelMeter::Default : FFAU::LevelMeter::SingleChannel),
-		hasVolume_(hasVolume), hasTarget_(hasTarget), hasPitch_(hasPitch), meterSource_(nullptr), channelNo_(0)
+		id_(id)
+        , hasVolume_(hasVolume)
+        , hasTarget_(hasTarget)
+        , hasPitch_(hasPitch)
+        , levelMeter_(name == "Master" ? FFAU::LevelMeter::Default : FFAU::LevelMeter::SingleChannel)
+        , meterSource_(nullptr)
+        , channelNo_(0)
 {
 	channelName_.setText(name, dontSendNotification);
 	if (hasVolume) {

--- a/Client/Source/Client.h
+++ b/Client/Source/Client.h
@@ -13,6 +13,8 @@
 #include "RingOfAudioBuffers.h"
 #include "ApplicationState.h"
 
+#include "nlohmann/json.hpp"
+
 struct ControlData
 {
 	std::optional<float> bpm;
@@ -25,6 +27,7 @@ public:
 	~Client();
 
 	bool sendData(JammerNetzChannelSetup const &channelSetup, std::shared_ptr<AudioBuffer<float>> audioBuffer, ControlData controllers);
+	bool sendControl(nlohmann::json &json);
 
 	// Statistics info
 	int getCurrentBlockSize() const;
@@ -32,12 +35,14 @@ public:
 private:
 	void setCryptoKey(const void* keyData, int keyBytes);
 	bool sendData(String const &remoteHostname, int remotePort, void *data, int numbytes);
+    bool sendBufferToServer(size_t totalBytes);
 
 	DatagramSocket &socket_;
 	uint64 messageCounter_;
 	uint8 sendBuffer_[65536];
 	std::atomic_int currentBlockSize_;
 	std::atomic<bool> useFEC_;
+	juce::CriticalSection socketLock_;
 	juce::CriticalSection serverLock_;
 	String serverName_;
 	std::atomic<int> serverPort_;

--- a/Client/Source/DataReceiveThread.cpp
+++ b/Client/Source/DataReceiveThread.cpp
@@ -99,7 +99,6 @@ void DataReceiveThread::run()
 							ScopedLock sessionLock(sessionDataLock_);
 							// Hand off to player
 							currentRTT_ = Time::getMillisecondCounterHiRes() - audioData->timestamp();
-							currentSession_ = audioData->sessionSetup(); //TODO - this is not thread safe, I trust
 							newDataHandler_(audioData);
 						}
 						break;
@@ -112,6 +111,13 @@ void DataReceiveThread::run()
 						}
 						break;
 					}
+                    case JammerNetzMessage::SESSIONSETUP: {
+                        auto sessionInfo = std::dynamic_pointer_cast<JammerNetzSessionInfoMessage>(message);
+                        if (sessionInfo) {
+                            currentSession_ = sessionInfo->channels_; //TODO - this is not thread safe, I trust
+                        }
+                        break;
+                    }
 					default:
 						// What's this?
 						jassert(false);

--- a/Client/Source/DataReceiveThread.cpp
+++ b/Client/Source/DataReceiveThread.cpp
@@ -118,6 +118,9 @@ void DataReceiveThread::run()
                         }
                         break;
                     }
+                    case JammerNetzMessage::MessageType::GENERIC_JSON:
+                        // Ignore for now
+                        break;
 					default:
 						// What's this?
 						jassert(false);

--- a/Client/Source/DeviceSelector.cpp
+++ b/Client/Source/DeviceSelector.cpp
@@ -16,7 +16,10 @@
 #include "LayoutConstants.h"
 
 DeviceSelector::DeviceSelector(String const& title, bool showTitle, bool inputInsteadOfOutputDevices)
-	: title_(title), showTitle_(showTitle), inputDevices_(inputInsteadOfOutputDevices)
+	:
+    showTitle_(showTitle)
+    , title_(title)
+    , inputDevices_(inputInsteadOfOutputDevices)
 {
 	titleLabel_.setText(title, dontSendNotification);
 
@@ -89,7 +92,7 @@ DeviceSelector::DeviceSelector(String const& title, bool showTitle, bool inputIn
 					// Does it have a control panel?
 					if (selectedDevice->hasControlPanel()) {
 						controlPanelButton_ = std::make_unique<TextButton>("Configure");
-						controlPanelButton_->onClick = [this, selectedDevice]() {
+						controlPanelButton_->onClick = [selectedDevice]() {
 							selectedDevice->showControlPanel();
 						};
 						addAndMakeVisible(*controlPanelButton_);
@@ -198,7 +201,7 @@ void DeviceSelector::resized()
 	return deviceTypes_[typeDropdown_.getSelectedItemIndex()];
 }*/
 
-bool comboHasText(ComboBox* combo, String text) {
+static bool comboHasText(ComboBox* combo, String text) {
 	for (int i = 0; i < combo->getNumItems(); i++) {
 		if (combo->getItemText(i) == text)
 			return true;
@@ -241,8 +244,8 @@ void DeviceSelector::bindControls()
 		deviceSelector.setProperty(VALUE_DEVICE_NAME, "", nullptr);
 	}
 	deviceDropdown_.onChange = [this]() {
-		ValueTree deviceSelector = Data::instance().get().getChildWithName(Identifier(titleLabel_.getText(false)));
-		deviceSelector.setProperty(VALUE_DEVICE_NAME, deviceDropdown_.getText(), nullptr);
+		ValueTree dropdownSelector = Data::instance().get().getChildWithName(Identifier(titleLabel_.getText(false)));
+        dropdownSelector.setProperty(VALUE_DEVICE_NAME, deviceDropdown_.getText(), nullptr);
 	};
 	listeners_.push_back(std::make_unique<ValueListener>(deviceSelector.getPropertyAsValue(VALUE_DEVICE_NAME, nullptr), [this](Value& newValue) {
 		String newType = newValue.getValue();

--- a/Client/Source/DeviceSelector.h
+++ b/Client/Source/DeviceSelector.h
@@ -14,7 +14,7 @@ class DeviceSelector : public Component
 {
 public:
 	DeviceSelector(String const &title, bool showTitle, bool inputInsteadOfOutputDevices);
-	virtual ~DeviceSelector();
+	virtual ~DeviceSelector() override;
 
 	virtual void resized() override;
 

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -9,7 +9,6 @@
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-float-conversion"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #pragma GCC diagnostic ignored "-Wsign-compare"
@@ -17,12 +16,19 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
 #endif
-#pragma warning( push )
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif
+#pragma warning(push)
 #pragma warning( disable: 4244 4100 4456 4702)
 #include "ff_meters/ff_meters.h"
 #pragma warning (pop )
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -7,22 +7,22 @@
 #pragma once
 
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
-#pragma clang diagnostic ignored "-Wfloat-conversion"
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#pragma clang diagnostic ignored "-Wsign-compare"
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#pragma clang diagnostic ignored "-Wshadow"
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-float-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
 #endif
 #pragma warning( push )
 #pragma warning( disable: 4244 4100 4456 4702)
 #include "ff_meters/ff_meters.h"
 #pragma warning (pop )
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -7,6 +7,7 @@
 #pragma once
 
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
 #pragma clang diagnostic ignored "-Wfloat-conversion"
@@ -17,8 +18,11 @@
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif
 #pragma warning( push )
 #pragma warning( disable: 4244 4100 4456 4702)
 #include "ff_meters/ff_meters.h"
 #pragma warning (pop )
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endifs

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -25,4 +25,4 @@
 #pragma warning (pop )
 #ifdef __clang__
 #pragma clang diagnostic pop
-#endifs
+#endif

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -9,10 +9,14 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Wfloat-conversion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
 #pragma warning( push )
 #pragma warning( disable: 4244 4100 4456 4702)
 #include "ff_meters/ff_meters.h"

--- a/Client/Source/IncludeFFMeters.h
+++ b/Client/Source/IncludeFFMeters.h
@@ -7,7 +7,14 @@
 #pragma once
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma warning( push )
 #pragma warning( disable: 4244 4100 4456 4702)
 #include "ff_meters/ff_meters.h"
 #pragma warning (pop )
+#pragma clang diagnostic pop

--- a/Client/Source/Main.cpp
+++ b/Client/Source/Main.cpp
@@ -72,7 +72,7 @@ public:
 		if (clientID.isNotEmpty()) {
 			windowTitle += ": " + clientID;
 		}
-        mainWindow = std::make_unique<MainWindow>(new MainComponent(clientID, audioService_, audioService_->getMasterRecorder(), audioService_->getLocalRecorder()), windowTitle, clientID);
+        mainWindow = std::make_unique<MainWindow>(new MainComponent(audioService_, audioService_->getMasterRecorder(), audioService_->getLocalRecorder()), windowTitle);
 
 #ifdef USE_SENTRY
 		// Initialize sentry for error crash reporting
@@ -130,7 +130,7 @@ public:
     class MainWindow    : public DocumentWindow
     {
     public:
-        MainWindow (Component *mainComponent, String name, String clientID)  : DocumentWindow (name,
+        MainWindow (Component *mainComponent, String name)  : DocumentWindow (name,
                                                     Desktop::getInstance().getDefaultLookAndFeel()
                                                                           .findColour (ResizableWindow::backgroundColourId),
                                                     DocumentWindow::allButtons)

--- a/Client/Source/MainComponent.cpp
+++ b/Client/Source/MainComponent.cpp
@@ -20,7 +20,7 @@
 
 #include "BuffersConfig.h"
 
-MainComponent::MainComponent(String clientID, std::shared_ptr<AudioService> audioService, std::shared_ptr<Recorder> masterRecorder, std::shared_ptr<Recorder> localRecorder) :
+MainComponent::MainComponent(std::shared_ptr<AudioService> audioService, std::shared_ptr<Recorder> masterRecorder, std::shared_ptr<Recorder> localRecorder) :
 	audioService_(audioService),
 	inputSelector_(VALUE_INPUT_SETUP, false, true),
 	outputSelector_(VALUE_OUTPUT_SETUP, false, false),
@@ -210,7 +210,6 @@ void MainComponent::resized()
 	auto outputArea = area.removeFromRight(masterMixerWidth + deviceSelectorWidth /* + playalongArea.getWidth()*/);
 
 	// Upper middle, other session participants
-	auto sessionArea = area;
 	sessionGroup_.setBounds(area);
 	allChannels_.setBounds(area.reduced(kNormalInset, kNormalInset));
 
@@ -332,7 +331,7 @@ void MainComponent::timerCallback()
 	}
 	// and for the session channels
 	if (currentSessionSetup_) {
-		for (int i = 0; i < currentSessionSetup_->channels.size(); i++) {
+		for (int i = 0; i < (int) currentSessionSetup_->channels.size(); i++) {
 			allChannels_.setPitchDisplayed(i, MidiNote(audioService_->sessionPitch(i)));
 		}
 	}

--- a/Client/Source/MainComponent.cpp
+++ b/Client/Source/MainComponent.cpp
@@ -26,9 +26,9 @@ MainComponent::MainComponent(std::shared_ptr<AudioService> audioService, std::sh
 	outputSelector_(VALUE_OUTPUT_SETUP, false, false),
 	outputController_("Master", VALUE_MASTER_OUTPUT, true, false),
 	monitorBalance_("Local", "Remote", 50),
-	logView_(false), // Turn off line numbers
-    stageLeftWhenInMillis_(Time::currentTimeMillis()),
-	bpmSlider_(juce::Slider::SliderStyle::LinearHorizontal, juce::Slider::TextBoxRight)
+	bpmSlider_(juce::Slider::SliderStyle::LinearHorizontal, juce::Slider::TextBoxRight),
+    logView_(false), // Turn off line numbers
+    stageLeftWhenInMillis_(Time::currentTimeMillis())
 {
 	// Create an a Logger for the JammerNetz client
 	logViewLogger_ = std::make_unique<LogViewLogger>(logView_);
@@ -327,12 +327,12 @@ void MainComponent::timerCallback()
 
 	// Refresh tuning info for my own channels
 	for (int i = 0; i < ownChannels_.numChannels(); i++) {
-		ownChannels_.setPitchDisplayed(i, MidiNote(audioService_->channelPitch(i)));
+		ownChannels_.setPitchDisplayed(i, MidiNote(audioService_->channelPitch((size_t) i)));
 	}
 	// and for the session channels
 	if (currentSessionSetup_) {
 		for (int i = 0; i < (int) currentSessionSetup_->channels.size(); i++) {
-			allChannels_.setPitchDisplayed(i, MidiNote(audioService_->sessionPitch(i)));
+			allChannels_.setPitchDisplayed(i, MidiNote(audioService_->sessionPitch((size_t) i)));
 		}
 	}
 

--- a/Client/Source/MainComponent.h
+++ b/Client/Source/MainComponent.h
@@ -24,8 +24,8 @@
 class MainComponent   : public Component, private Timer, public ValueTree::Listener
 {
 public:
-    MainComponent(String clientID, std::shared_ptr<AudioService> audioService, std::shared_ptr<Recorder> masterRecorder, std::shared_ptr<Recorder> localRecorder);
-    ~MainComponent();
+    MainComponent(std::shared_ptr<AudioService> audioService, std::shared_ptr<Recorder> masterRecorder, std::shared_ptr<Recorder> localRecorder);
+    virtual ~MainComponent() override;
 
     void resized() override;
 

--- a/Client/Source/MidiSendThread.cpp
+++ b/Client/Source/MidiSendThread.cpp
@@ -45,9 +45,7 @@ void MidiSendThread::run()
 			MessageQueueItem item;
 			while (midiMessages.try_pop(item) && !threadShouldExit()) {
 				// Wait until the time has come
-				uint64 waiting = 0;
 				while (std::chrono::high_resolution_clock::now() < item.whenToSend) {
-					waiting += 1;
 				}
 				// Send the F8 MIDI Clock message to all devices registered
 				for (auto &out : f8_outputs) {

--- a/Client/Source/MidiSendThread.h
+++ b/Client/Source/MidiSendThread.h
@@ -4,7 +4,10 @@
 
 #include "MidiController.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextra-semi"
 #include "tbb/concurrent_queue.h"
+#pragma clang diagnostic pop
 
 #include <chrono>
 #include <deque>
@@ -13,7 +16,7 @@
 class MidiSendThread : juce::Thread {
 public:
 	MidiSendThread(std::vector<juce::MidiDeviceInfo> const outputs);
-	virtual ~MidiSendThread();
+	virtual ~MidiSendThread() override;
 
 	void enqueue(std::chrono::high_resolution_clock::duration fromNow, std::vector<MidiMessage> const &messages);
 

--- a/Client/Source/MidiSendThread.h
+++ b/Client/Source/MidiSendThread.h
@@ -4,10 +4,14 @@
 
 #include "MidiController.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wextra-semi"
+#endif
 #include "tbb/concurrent_queue.h"
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #include <chrono>
 #include <deque>

--- a/Client/Source/MidiSendThread.h
+++ b/Client/Source/MidiSendThread.h
@@ -4,13 +4,13 @@
 
 #include "MidiController.h"
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextra-semi"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra-semi"
 #endif
 #include "tbb/concurrent_queue.h"
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif
 
 #include <chrono>

--- a/Client/Source/PlayalongDisplay.h
+++ b/Client/Source/PlayalongDisplay.h
@@ -13,7 +13,7 @@
 class PlayalongDisplay : public Component, private Button::Listener, private Timer {
 public:
 	PlayalongDisplay(MidiPlayAlong *playalong);
-	virtual ~PlayalongDisplay();
+	virtual ~PlayalongDisplay() override;
 
 	virtual void resized() override;
 

--- a/Client/Source/RecordingInfo.cpp
+++ b/Client/Source/RecordingInfo.cpp
@@ -13,7 +13,7 @@
 
 // https://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java
 //
-String humanReadableByteCount(size_t bytes, bool si) {
+static String humanReadableByteCount(size_t bytes, bool si) {
 	size_t unit = si ? 1000 : 1024;
 	if (bytes < unit) {
 		return String(bytes) + " B";
@@ -31,7 +31,7 @@ String humanReadableByteCount(size_t bytes, bool si) {
 
 class RecordingInfo::UpdateTimer : public Timer {
 public:
-	UpdateTimer(RecordingInfo *info) : info_(info) {};
+	UpdateTimer(RecordingInfo *info) : info_(info) {}
 
 	virtual void timerCallback() override
 	{
@@ -128,7 +128,7 @@ void RecordingInfo::updateData()
 		auto dir = recorder_.lock()->getDirectory();
 		recordingPath_.setText(dir.getFullPathName(), dontSendNotification);
 		diskSpacePercentage_ =  1.0 - dir.getBytesFreeOnVolume() / (double)dir.getVolumeTotalSize();
-		diskSpace_.setTextToDisplay(humanReadableByteCount(dir.getBytesFreeOnVolume(), false));
+		diskSpace_.setTextToDisplay(humanReadableByteCount((size_t) dir.getBytesFreeOnVolume(), false));
 		bool isLive = recorder_.lock()->isRecording();
 		recording_.setToggleState(!isLive, dontSendNotification);
 

--- a/Client/Source/RecordingInfo.cpp
+++ b/Client/Source/RecordingInfo.cpp
@@ -42,7 +42,7 @@ private:
 	RecordingInfo *info_;
 };
 
-RecordingInfo::RecordingInfo(std::weak_ptr<Recorder> recorder, String explanation) : recorder_(recorder), diskSpace_(diskSpacePercentage_), diskSpacePercentage_(0.0)
+RecordingInfo::RecordingInfo(std::weak_ptr<Recorder> recorder, String explanation) : recorder_(recorder), diskSpacePercentage_(0.0), diskSpace_(diskSpacePercentage_)
 {
 	explanationText_.setText(explanation, dontSendNotification);
 	addAndMakeVisible(explanationText_);

--- a/Client/Source/RecordingInfo.h
+++ b/Client/Source/RecordingInfo.h
@@ -34,6 +34,6 @@ private:
 	ImageButton recording_;
 	Label recordingTime_;
 	Label freeDiskSpace_;
-	ProgressBar diskSpace_;
 	double diskSpacePercentage_;
+	ProgressBar diskSpace_;
 };

--- a/Client/Source/RecordingInfo.h
+++ b/Client/Source/RecordingInfo.h
@@ -13,7 +13,7 @@
 class RecordingInfo : public Component, private TextButton::Listener {
 public:
 	RecordingInfo(std::weak_ptr<Recorder> recorder, String explanation);
-	~RecordingInfo();
+	virtual ~RecordingInfo() override;
 
 	virtual void resized() override;
 

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -25,6 +25,7 @@
 #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#pragma clang diagnostic ignored "-Wc99-extensions"
 #endif
 #include <q/pitch/pitch_detector.hpp>
 #ifdef __clang__

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -12,6 +12,7 @@
 #pragma warning( push )
 #pragma warning( disable: 4244 4267 4305 4456)
 #endif
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-conversion"
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -24,8 +25,11 @@
 #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#endif
 #include <q/pitch/pitch_detector.hpp>
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 #ifndef __GNUC__
 #pragma warning ( pop )
 #endif

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -8,10 +8,28 @@
 
 #include "BuffersConfig.h"
 
+#ifndef __GNUC__
 #pragma warning( push )
 #pragma warning( disable: 4244 4267 4305 4456)
+#endif
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+#pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #include <q/pitch/pitch_detector.hpp>
+#pragma clang diagnostic pop
+#ifndef __GNUC__
 #pragma warning ( pop )
+#endif
+
 
 namespace q = cycfi::q;
 using namespace q::literals;
@@ -22,21 +40,21 @@ public:
 		if (audioData) {
 
 			auto readPointers = audioData->getArrayOfReadPointers();
-			for (int channel = 0; channel < audioData->getNumChannels(); channel++) {
+			for (size_t channel = 0; channel < (size_t) audioData->getNumChannels(); channel++) {
 				// Do we already create a detector for this channel?
 				if (detectors.size() <= channel) {
 					detectors.push_back(std::make_unique<q::pitch_detector>(50.0_Hz, 2000.0_Hz, (float) SAMPLE_RATE, q::lin_to_db(0.0)));
 				}
 
 				// Feed the samples of this channel into the pitch detector
-				for (int s = 0; s < audioData->getNumSamples(); s++) {
+				for (size_t s = 0; s < (size_t) audioData->getNumSamples(); s++) {
 					(*detectors[channel])(readPointers[channel][s]);
 				}
 			}
 		}
 	}
 
-	float getPitch(int channel) const {
+	float getPitch(size_t channel) const {
 		if (channel < detectors.size()) {
 			return detectors[channel]->predict_frequency();
 		}
@@ -61,7 +79,7 @@ void Tuner::detectPitch(std::shared_ptr<AudioBuffer<float>> audioBuffer)
 	impl->detectPitch(audioBuffer);
 }
 
-float Tuner::getPitch(int channel) const
+float Tuner::getPitch(size_t channel) const
 {
 	return impl->getPitch(channel);
 }

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -14,19 +14,21 @@
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wimplicit-float-conversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
-#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
-#pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
 #pragma GCC diagnostic ignored "-Wextra-semi"
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wshadow-field-in-constructor"
-#pragma GCC diagnostic ignored "-Wimplicit-int-conversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wgnu-statement-expression"
-#pragma GCC diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+#pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wc99-extensions"
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
 #endif
 #include <q/pitch/pitch_detector.hpp>
 #ifndef __GNUC__

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -26,6 +26,7 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wc99-extensions"
+#pragma clang diagnostic ignored "-Wno-gnu-statement-expression"
 #endif
 #include <q/pitch/pitch_detector.hpp>
 #ifdef __clang__

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -11,30 +11,28 @@
 #ifndef __GNUC__
 #pragma warning( push )
 #pragma warning( disable: 4244 4267 4305 4456)
-#endif
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-conversion"
-#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
-#pragma clang diagnostic ignored "-Wextra-semi"
-#pragma clang diagnostic ignored "-Wshadow"
-#pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
-#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wimplicit-float-conversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
+#pragma GCC diagnostic ignored "-Wextra-semi"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wshadow-field-in-constructor"
+#pragma GCC diagnostic ignored "-Wimplicit-int-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wc99-extensions"
+#pragma GCC diagnostic ignored "-Wgnu-statement-expression"
+#pragma GCC diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
 #endif
 #include <q/pitch/pitch_detector.hpp>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 #ifndef __GNUC__
-#pragma warning ( pop )
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
 #endif
 
 

--- a/Client/Source/Tuner.cpp
+++ b/Client/Source/Tuner.cpp
@@ -26,7 +26,8 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma clang diagnostic ignored "-Wno-gnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
 #endif
 #include <q/pitch/pitch_detector.hpp>
 #ifdef __clang__

--- a/Client/Source/Tuner.h
+++ b/Client/Source/Tuner.h
@@ -15,7 +15,7 @@ public:
 	~Tuner();
 
 	void detectPitch(std::shared_ptr<AudioBuffer<float>> audioBuffer);
-	float getPitch(int channel) const;
+	float getPitch(size_t channel) const;
 
 private:
 	// We might want to try different pitch detection libraries, therefore hide the implementation

--- a/Client/Source/version.cpp.in
+++ b/Client/Source/version.cpp.in
@@ -4,7 +4,7 @@
    Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
 */
 
-std::string getClientVersion()
+static std::string getClientVersion()
 {
     return "@JammerNetzClient_VERSION@";
 }

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -59,6 +59,5 @@ if (MSVC)
     target_compile_options(JammerNetzServer PRIVATE /W4 /WX)
 else()
     # lots of warnings and all warnings as errors
-    #target_compile_options(JammerNetzServer PRIVATE -Wall -Wextra -pedantic -Werror)
-    target_compile_options(JammerNetzServer PRIVATE -Werror)
+    target_compile_options(JammerNetzServer PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -60,4 +60,5 @@ if (MSVC)
 else()
     # lots of warnings and all warnings as errors
     #target_compile_options(JammerNetzServer PRIVATE -Wall -Wextra -pedantic -Werror)
+    target_compile_options(JammerNetzServer PRIVATE -Werror)
 endif()

--- a/Server/Source/AcceptThread.cpp
+++ b/Server/Source/AcceptThread.cpp
@@ -29,8 +29,13 @@ private:
 	TPacketStreamBundle &data_;
 };
 
-AcceptThread::AcceptThread(int serverPort, DatagramSocket &socket, TPacketStreamBundle &incomingData, TMessageQueue &wakeUpQueue, ServerBufferConfig bufferConfig, void *keydata, int keysize)
-	: Thread("ReceiverThread"), receiveSocket_(socket), incomingData_(incomingData), wakeUpQueue_(wakeUpQueue), bufferConfig_(bufferConfig)
+AcceptThread::AcceptThread(int serverPort, DatagramSocket &socket, TPacketStreamBundle &incomingData, TMessageQueue &wakeUpQueue, ServerBufferConfig bufferConfig, void *keydata, int keysize, ValueTree serverConfiguration)
+	: Thread("ReceiverThread")
+    , receiveSocket_(socket)
+    , incomingData_(incomingData)
+    , wakeUpQueue_(wakeUpQueue)
+    , serverConfiguration_(serverConfiguration)
+    , bufferConfig_(bufferConfig)
 {
 	if (keydata) {
 		blowFish_ = std::make_unique<BlowFish>(keydata, keysize);
@@ -55,7 +60,9 @@ void AcceptThread::processControlMessage(std::shared_ptr<JammerNetzControlMessag
 {
     if (message)
     {
-
+        if (message->json_.contains("FEC")) {
+            serverConfiguration_.setProperty("FEC", message->json_["FEC"].operator bool(), nullptr);
+        }
     }
 }
 

--- a/Server/Source/AcceptThread.h
+++ b/Server/Source/AcceptThread.h
@@ -11,17 +11,22 @@
 #include "SharedServerTypes.h"
 #include "BuffersConfig.h"
 
+#include "JammerNetzPackage.h"
+
 class PrintQualityTimer;
 
 class AcceptThread : public Thread {
 public:
 	AcceptThread(int serverPort, DatagramSocket &socket, TPacketStreamBundle &incomingData, TMessageQueue &wakeUpQueue, ServerBufferConfig bufferConfig, void *keydata, int keysize);
-	~AcceptThread();
+	virtual ~AcceptThread() override;
 
 	virtual void run() override;
 
 private:
-	DatagramSocket &receiveSocket_;
+    void processControlMessage(std::shared_ptr<JammerNetzControlMessage> message);
+    void processAudioMessage(std::shared_ptr<JammerNetzAudioData> message, std::string const& clientName);
+
+    DatagramSocket &receiveSocket_;
 	TPacketStreamBundle &incomingData_;
 	TMessageQueue &wakeUpQueue_;
 	uint8 readbuffer[MAXFRAMESIZE];

--- a/Server/Source/AcceptThread.h
+++ b/Server/Source/AcceptThread.h
@@ -17,7 +17,12 @@ class PrintQualityTimer;
 
 class AcceptThread : public Thread {
 public:
-	AcceptThread(int serverPort, DatagramSocket &socket, TPacketStreamBundle &incomingData, TMessageQueue &wakeUpQueue, ServerBufferConfig bufferConfig, void *keydata, int keysize);
+	AcceptThread(int serverPort, DatagramSocket &socket,
+                 TPacketStreamBundle &incomingData, TMessageQueue &wakeUpQueue,
+                 ServerBufferConfig bufferConfig,
+                 void *keydata,
+                 int keysize,
+                 ValueTree serverConfiguration);
 	virtual ~AcceptThread() override;
 
 	virtual void run() override;
@@ -29,6 +34,7 @@ private:
     DatagramSocket &receiveSocket_;
 	TPacketStreamBundle &incomingData_;
 	TMessageQueue &wakeUpQueue_;
+    ValueTree serverConfiguration_;
 	uint8 readbuffer[MAXFRAMESIZE];
 	std::unique_ptr<PrintQualityTimer> qualityTimer_;
 	ServerBufferConfig bufferConfig_;

--- a/Server/Source/Main.cpp
+++ b/Server/Source/Main.cpp
@@ -36,7 +36,7 @@
 class Server {
 public:
 	Server(std::shared_ptr<MemoryBlock> cryptoKey, ServerBufferConfig bufferConfig, int serverPort, bool useFEC) : mixdownRecorder_(File::getCurrentWorkingDirectory(), "mixdown", RecordingType::FLAC), clientRecorder_(File(), "input", RecordingType::AIFF),
-		mixdownSetup_(false, { JammerNetzChannelTarget::Left, JammerNetzChannelTarget::Right }) // Setup standard mix down setup - two channels only in stereo
+		mixdownSetup_(false, { JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left), JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right) }) // Setup standard mix down setup - two channels only in stereo
 	{
 		// Start the recorder of the mix down
 		//mixdownRecorder_.updateChannelInfo(48000, mixdownSetup_);

--- a/Server/Source/Main.cpp
+++ b/Server/Source/Main.cpp
@@ -19,6 +19,8 @@
 
 #include "ServerLogger.h"
 
+std::string getServerVersion();
+
 #include "version.cpp"
 
 #ifdef WIN32
@@ -35,8 +37,10 @@
 
 class Server {
 public:
-	Server(std::shared_ptr<MemoryBlock> cryptoKey, ServerBufferConfig bufferConfig, int serverPort, bool useFEC) : mixdownRecorder_(File::getCurrentWorkingDirectory(), "mixdown", RecordingType::FLAC), clientRecorder_(File(), "input", RecordingType::AIFF),
-		mixdownSetup_(false, { JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left), JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right) }) // Setup standard mix down setup - two channels only in stereo
+	Server(std::shared_ptr<MemoryBlock> cryptoKey, ServerBufferConfig bufferConfig, int serverPort, bool useFEC) :
+    clientRecorder_(File(), "input", RecordingType::AIFF)
+    , mixdownRecorder_(File::getCurrentWorkingDirectory(), "mixdown", RecordingType::FLAC)
+    , mixdownSetup_(false, { JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left), JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right) }) // Setup standard mix down setup - two channels only in stereo
 	{
 		// Start the recorder of the mix down
 		//mixdownRecorder_.updateChannelInfo(48000, mixdownSetup_);
@@ -51,7 +55,7 @@ public:
 
 		acceptThread_ = std::make_unique<AcceptThread>(serverPort, socket_, incomingStreams_, wakeUpQueue_, bufferConfig, cryptoData, cipherLength);
 		sendThread_ = std::make_unique <SendThread>(socket_, sendQueue_, incomingStreams_, cryptoData, cipherLength, useFEC);
-		mixerThread_ = std::make_unique<MixerThread>(incomingStreams_, mixdownSetup_, sendQueue_, wakeUpQueue_, mixdownRecorder_, bufferConfig);
+		mixerThread_ = std::make_unique<MixerThread>(incomingStreams_, mixdownSetup_, sendQueue_, wakeUpQueue_, bufferConfig);
 
 		sendQueue_.set_capacity(128); // This is an arbitrary number only to prevent memory overflow should the sender thread somehow die (i.e. no network or something)
 	}
@@ -110,10 +114,10 @@ int main(int argc, char *argv[])
 	std::shared_ptr<MemoryBlock> cryptoKey;
 
 	// Parse command line arguments
-	ArgumentList args(argc, argv);
+	ArgumentList arguments(argc, argv);
 
 	// Sweet executable name
-	File myself(args.executableName);
+	File myself(arguments.executableName);
 	String shortExeName = myself.getFileName();
 
 	// Specify commands
@@ -173,7 +177,7 @@ int main(int argc, char *argv[])
 	sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO, "custom", "Launching JammerNetzServer"));
 #endif
 
-	app.findAndRunCommand(args);
+	app.findAndRunCommand(arguments);
 
 #ifdef USE_SENTRY
 	std::cout << "Shutting down Sentry" << std::endl;

--- a/Server/Source/MixerThread.cpp
+++ b/Server/Source/MixerThread.cpp
@@ -132,9 +132,9 @@ void MixerThread::run() {
 					midiSignal,
 					48000,
 					mixdownSetup_,
-					outBuffer,
-					sessionSetup
-					));
+					outBuffer),
+                    sessionSetup
+					);
 				if (!outgoing_.try_push(package)) {
 					// That's a bad sign - I would assume the sender thread died and that's possibly because the network is down.
 					// Abort

--- a/Server/Source/MixerThread.cpp
+++ b/Server/Source/MixerThread.cpp
@@ -93,7 +93,7 @@ void MixerThread::run() {
 		if (incomingData.size() > 0) {
 			//TODO - current assumption: all clients provide buffers of the same size. Therefore, take the length of the first client as the output size
 			int bufferLength = (*incomingData.begin()).second->audioBuffer()->getNumSamples();
-			serverTime_ += (size_t) bufferLength; // Server time counts time of mixing thread in samples mixed since launch
+			serverTime_ += (juce::uint64) bufferLength; // Server time counts time of mixing thread in samples mixed since launch
 
 			// For each client that has delivered data, produce a mix down package and send it back
 			//TODO - also the clients that have not provided data should get a package with a note that they are not contained within - they could do a local fill in.

--- a/Server/Source/MixerThread.cpp
+++ b/Server/Source/MixerThread.cpp
@@ -9,10 +9,16 @@
 #include "BuffersConfig.h"
 #include "ServerLogger.h"
 
-MixerThread::MixerThread(TPacketStreamBundle &incoming, JammerNetzChannelSetup mixdownSetup, TOutgoingQueue &outgoing, TMessageQueue &wakeUpQueue, Recorder &recorder, ServerBufferConfig bufferConfig) :
-    Thread("MixerThread"),
-    incoming_(incoming), mixdownSetup_(mixdownSetup), outgoing_(outgoing), wakeUpQueue_(wakeUpQueue), recorder_(recorder), bufferConfig_(bufferConfig), serverTime_(0),
-    lastBpm_(120.0f)
+MixerThread::MixerThread(TPacketStreamBundle &incoming, JammerNetzChannelSetup mixdownSetup, TOutgoingQueue &outgoing, TMessageQueue &wakeUpQueue/*, Recorder &recorder*/, ServerBufferConfig bufferConfig) :
+    Thread("MixerThread")
+        , serverTime_(0)
+        , lastBpm_(120.0f)
+        , incoming_(incoming)
+        , outgoing_(outgoing)
+        , wakeUpQueue_(wakeUpQueue)
+        , mixdownSetup_(mixdownSetup)
+        /*, recorder_(recorder) */
+        , bufferConfig_(bufferConfig)
 {
 }
 
@@ -33,8 +39,8 @@ void MixerThread::run() {
 		for (auto &inqueue : incoming_) {
 			if (inqueue.second) {
 				clientCount++;
-				if (inqueue.second->size() > bufferConfig_.serverIncomingJitterBuffer) available++;
-				if (inqueue.second->size() > bufferConfig_.serverIncomingMaximumBuffer) queueOverrun = true; // This is one client much faster than the others
+				if ((int)inqueue.second->size() > bufferConfig_.serverIncomingJitterBuffer) available++;
+				if ((int)inqueue.second->size() > bufferConfig_.serverIncomingMaximumBuffer) queueOverrun = true; // This is one client much faster than the others
 			}
 		}
 		if (clientCount == available) allHaveDelivered = true;
@@ -87,7 +93,7 @@ void MixerThread::run() {
 		if (incomingData.size() > 0) {
 			//TODO - current assumption: all clients provide buffers of the same size. Therefore, take the length of the first client as the output size
 			int bufferLength = (*incomingData.begin()).second->audioBuffer()->getNumSamples();
-			serverTime_ += bufferLength; // Server time counts time of mixing thread in samples mixed since launch
+			serverTime_ += (size_t) bufferLength; // Server time counts time of mixing thread in samples mixed since launch
 
 			// For each client that has delivered data, produce a mix down package and send it back
 			//TODO - also the clients that have not provided data should get a package with a note that they are not contained within - they could do a local fill in.
@@ -168,7 +174,7 @@ void MixerThread::bufferMixdown(std::shared_ptr<AudioBuffer<float>> &outBuffer, 
 	auto channelSetup = audioData->channelSetup();
 	bool wantsEcho = !channelSetup.isLocalMonitoringDontSendEcho;
 	for (int channel = 0; channel < audioData->audioBuffer()->getNumChannels(); channel++) {
-		JammerNetzSingleChannelSetup setup = channelSetup.channels[channel];
+		JammerNetzSingleChannelSetup setup = channelSetup.channels[(size_t)channel];
 		switch (setup.target) {
 		case Mute:
 			// Nothing to be done

--- a/Server/Source/MixerThread.h
+++ b/Server/Source/MixerThread.h
@@ -16,7 +16,9 @@
 
 class MixerThread : public Thread {
 public:
-	MixerThread(TPacketStreamBundle &incoming, JammerNetzChannelSetup mixdownSetup, TOutgoingQueue &outgoing, TMessageQueue &wakeUpQueue, Recorder &recorder, ServerBufferConfig bufferConfig);
+	MixerThread(TPacketStreamBundle &incoming, JammerNetzChannelSetup mixdownSetup, TOutgoingQueue &outgoing, TMessageQueue &wakeUpQueue
+                /*, Recorder &recorder*/
+                , ServerBufferConfig bufferConfig);
 
 	virtual void run() override;
 
@@ -29,6 +31,6 @@ private:
 	TOutgoingQueue &outgoing_;
 	TMessageQueue &wakeUpQueue_;
 	JammerNetzChannelSetup mixdownSetup_;
-	Recorder &recorder_;
+	//Recorder &recorder_;
 	ServerBufferConfig bufferConfig_;
 };

--- a/Server/Source/SendThread.cpp
+++ b/Server/Source/SendThread.cpp
@@ -77,6 +77,21 @@ void SendThread::sendClientInfoPackage(std::string const &targetAddress)
 	sendWriteBuffer(ipAddress, port, bytesWritten);
 }
 
+void SendThread::sendSessionInfoPackage(std::string const &targetAddress, JammerNetzChannelSetup &sessionSetup)
+{
+    // Loop over the incoming data streams and add them to our statistics package we are going to send to the client
+    JammerNetzSessionInfoMessage sessionInfoMessage;
+    sessionInfoMessage.channels_.channels = sessionSetup.channels;
+
+    size_t bytesWritten = 0;
+    sessionInfoMessage.serialize(writebuffer_, bytesWritten);
+
+    String ipAddress;
+    int port;
+    determineTargetIP(targetAddress, ipAddress, port);
+    sendWriteBuffer(ipAddress, port, bytesWritten);
+}
+
 void SendThread::sendWriteBuffer(String ipAddress, int port, size_t size) {
 	if (sizet_is_safe_as_int(size)) {
 		int cipherLength = static_cast<int>(size);
@@ -118,6 +133,7 @@ void SendThread::run()
 		}
 		if (packageCounters_[nextBlock.targetAddress] % 100 == 0) {
 			sendClientInfoPackage(nextBlock.targetAddress);
+            sendSessionInfoPackage(nextBlock.targetAddress, nextBlock.sessionSetup);
 		}
 		packageCounters_[nextBlock.targetAddress]++;
 	}

--- a/Server/Source/SendThread.cpp
+++ b/Server/Source/SendThread.cpp
@@ -11,7 +11,11 @@
 #include "ServerLogger.h"
 
 SendThread::SendThread(DatagramSocket& socket, TOutgoingQueue &sendQueue, TPacketStreamBundle &incomingData, void *keydata, int keysize, bool useFEC)
-	: Thread("SenderThread"), sendSocket_(socket), sendQueue_(sendQueue), incomingData_(incomingData), useFEC_(useFEC)
+	: Thread("SenderThread")
+    , sendQueue_(sendQueue)
+    , incomingData_(incomingData)
+    , sendSocket_(socket)
+    , useFEC_(useFEC)
 {
 	if (keydata) {
 		blowFish_ = std::make_unique<BlowFish>(keydata, keysize);

--- a/Server/Source/SendThread.h
+++ b/Server/Source/SendThread.h
@@ -21,7 +21,8 @@ public:
 private:
 	void determineTargetIP(std::string const &targetAddress, String &ipAddress, int &portNumber);
 	void sendWriteBuffer(String ipAddress, int port, size_t size);
-	void sendClientInfoPackage(std::string const &targetAddress);
+    void sendSessionInfoPackage(std::string const &targetAddress, JammerNetzChannelSetup &sessionSetup);
+    void sendClientInfoPackage(std::string const &targetAddress);
 	void sendAudioBlock(std::string const &targetAddress, AudioBlock &audioBlock);
 
 	TOutgoingQueue& sendQueue_;

--- a/Server/Source/SendThread.h
+++ b/Server/Source/SendThread.h
@@ -14,7 +14,7 @@
 
 class SendThread : public Thread {
 public:
-	SendThread(DatagramSocket& socket, TOutgoingQueue &sendQueue, TPacketStreamBundle &incomingData, void *keydata, int keysize, bool useFEC);
+	SendThread(DatagramSocket& socket, TOutgoingQueue &sendQueue, TPacketStreamBundle &incomingData, void *keydata, int keysize, ValueTree serverConfiguration);
 
 	virtual void run() override;
 
@@ -28,7 +28,7 @@ private:
 	TOutgoingQueue& sendQueue_;
 	TPacketStreamBundle &incomingData_;
 	DatagramSocket& sendSocket_;
-	bool useFEC_;
+    ValueTree serverConfiguration_;
 	uint8 writebuffer_[MAXFRAMESIZE];
 	std::map<std::string, RingOfAudioBuffers<AudioBlock>> fecData_;
 	std::map<std::string, uint64_t> packageCounters_;

--- a/Server/Source/ServerLogger.cpp
+++ b/Server/Source/ServerLogger.cpp
@@ -10,6 +10,11 @@
 
 static SCREEN *terminal;
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
+
 void ServerLogger::init()
 {
 	// We're good to good, init screen if possible
@@ -41,14 +46,7 @@ void ServerLogger::printAtPosition(int x, int y, std::string text)
 {
 	if (terminal) {
 		move(x, y);
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
-#endif
 		printw(text.c_str());
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 		refresh();
 	}
 	else {
@@ -98,9 +96,6 @@ void ServerLogger::printStatistics(int row, std::string const &clientID, JammerN
 #ifndef __GNUC__
 #pragma warning( push )
 #pragma warning( disable : 4996 )
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
 #endif
 		snprintf(buffer, 200, "%*d", 6, (int)(quality.packagesPushed - quality.packagesPopped));	mvprintw(y, kColumnHeaders[1].first, buffer);
 		snprintf(buffer, 200, "%*d", 6, (int)quality.outOfOrderPacketCounter);	mvprintw(y, kColumnHeaders[2].first, buffer);
@@ -114,8 +109,6 @@ void ServerLogger::printStatistics(int row, std::string const &clientID, JammerN
 		snprintf(buffer, 200, "%2.1f", quality.jitterSDMillis);	mvprintw(y, kColumnHeaders[10].first, buffer);
 #ifndef __GNUC__
 #pragma warning( pop )
-#else
-#pragma GCC diagnostic pop
 #endif
 		refresh();
 	}
@@ -168,3 +161,7 @@ void ServerLogger::printClientStatus(int row, std::string const &clientID, std::
 juce::String ServerLogger::lastMessage;
 
 long long ServerLogger::counter = 0;
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/Server/Source/ServerLogger.cpp
+++ b/Server/Source/ServerLogger.cpp
@@ -41,7 +41,14 @@ void ServerLogger::printAtPosition(int x, int y, std::string text)
 {
 	if (terminal) {
 		move(x, y);
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
 		printw(text.c_str());
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 		refresh();
 	}
 	else {
@@ -91,6 +98,9 @@ void ServerLogger::printStatistics(int row, std::string const &clientID, JammerN
 #ifndef __GNUC__
 #pragma warning( push )
 #pragma warning( disable : 4996 )
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 #endif
 		snprintf(buffer, 200, "%*d", 6, (int)(quality.packagesPushed - quality.packagesPopped));	mvprintw(y, kColumnHeaders[1].first, buffer);
 		snprintf(buffer, 200, "%*d", 6, (int)quality.outOfOrderPacketCounter);	mvprintw(y, kColumnHeaders[2].first, buffer);
@@ -104,6 +114,8 @@ void ServerLogger::printStatistics(int row, std::string const &clientID, JammerN
 		snprintf(buffer, 200, "%2.1f", quality.jitterSDMillis);	mvprintw(y, kColumnHeaders[10].first, buffer);
 #ifndef __GNUC__
 #pragma warning( pop )
+#else
+#pragma GCC diagnostic pop
 #endif
 		refresh();
 	}

--- a/Server/Source/ServerLogger.cpp
+++ b/Server/Source/ServerLogger.cpp
@@ -55,7 +55,7 @@ std::vector<std::pair<int, std::string>> kColumnHeaders = { {0, "Client"}, {20, 
 std::map<std::string, int> sClientRows;
 int kRowsInTable = 0;
 
-int yForClient(std::string const &clientID) {
+static int yForClient(std::string const &clientID) {
 	if (sClientRows.find(clientID) == sClientRows.end()) {
 		sClientRows[clientID] = kRowsInTable++;
 	}
@@ -88,19 +88,23 @@ void ServerLogger::printStatistics(int row, std::string const &clientID, JammerN
 		char buffer[200];
 		//snprintf(buffer, 200, "%6d", (int)quality.packagesPushed);	mvprintw(y, 20, buffer);
 		//snprintf(buffer, 200, "%6d", (int)quality.packagesPopped);	mvprintw(y, 28, buffer);
+#ifndef __GNUC__
 #pragma warning( push )
 #pragma warning( disable : 4996 )
-		sprintf(buffer, "%*d", 6, (int)(quality.packagesPushed - quality.packagesPopped));	mvprintw(y, kColumnHeaders[1].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.outOfOrderPacketCounter);	mvprintw(y, kColumnHeaders[2].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.maxWrongOrderSpan);	mvprintw(y, kColumnHeaders[3].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.duplicatePacketCounter);	mvprintw(y, kColumnHeaders[4].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.dropsHealed);	mvprintw(y, kColumnHeaders[5].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.tooLateOrDuplicate);	mvprintw(y, kColumnHeaders[6].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.droppedPacketCounter);	mvprintw(y, kColumnHeaders[7].first, buffer);
-		sprintf(buffer, "%*d", 6, (int)quality.maxLengthOfGap);	mvprintw(y, kColumnHeaders[8].first, buffer);
-		sprintf(buffer, "%2.1f", quality.jitterMeanMillis);	mvprintw(y, kColumnHeaders[9].first, buffer);
-		sprintf(buffer, "%2.1f", quality.jitterSDMillis);	mvprintw(y, kColumnHeaders[10].first, buffer);
+#endif
+		snprintf(buffer, 200, "%*d", 6, (int)(quality.packagesPushed - quality.packagesPopped));	mvprintw(y, kColumnHeaders[1].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.outOfOrderPacketCounter);	mvprintw(y, kColumnHeaders[2].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.maxWrongOrderSpan);	mvprintw(y, kColumnHeaders[3].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.duplicatePacketCounter);	mvprintw(y, kColumnHeaders[4].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.dropsHealed);	mvprintw(y, kColumnHeaders[5].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.tooLateOrDuplicate);	mvprintw(y, kColumnHeaders[6].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.droppedPacketCounter);	mvprintw(y, kColumnHeaders[7].first, buffer);
+		snprintf(buffer, 200, "%*d", 6, (int)quality.maxLengthOfGap);	mvprintw(y, kColumnHeaders[8].first, buffer);
+		snprintf(buffer, 200, "%2.1f", quality.jitterMeanMillis);	mvprintw(y, kColumnHeaders[9].first, buffer);
+		snprintf(buffer, 200, "%2.1f", quality.jitterSDMillis);	mvprintw(y, kColumnHeaders[10].first, buffer);
+#ifndef __GNUC__
 #pragma warning( pop )
+#endif
 		refresh();
 	}
 }

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -11,15 +11,15 @@
 #include "JammerNetzPackage.h"
 #include "PacketStreamQueue.h"
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextra-semi"
-#pragma clang diagnostic ignored "-Wsign-conversion"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra-semi"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_unordered_map.h"
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif
 #include <string>
 #include <set>

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -11,8 +11,14 @@
 #include "JammerNetzPackage.h"
 #include "PacketStreamQueue.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_unordered_map.h"
+
+#pragma clang diagnostic pop
 
 #include <string>
 #include <set>

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -11,15 +11,16 @@
 #include "JammerNetzPackage.h"
 #include "PacketStreamQueue.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wsign-conversion"
-
+#endif
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_unordered_map.h"
-
+#ifdef __clang__
 #pragma clang diagnostic pop
-
+#endif
 #include <string>
 #include <set>
 

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -14,16 +14,20 @@
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_unordered_map.h"
 
+#include <string>
 #include <set>
 
-struct OutgoingPackage {
-	OutgoingPackage() = default;
-	OutgoingPackage(std::string const &targetAddress, AudioBlock const &audioBlock) :
-		targetAddress(targetAddress), audioBlock(audioBlock) {
+class OutgoingPackage {
+public:
+	OutgoingPackage() : targetAddress(""), audioBlock(), sessionSetup(false) {}
+
+	OutgoingPackage(std::string const &targetAddress_, AudioBlock const &audioBlock_, JammerNetzChannelSetup sessionSetup_) :
+		targetAddress(targetAddress_), audioBlock(audioBlock_), sessionSetup(sessionSetup_) {
 	}
 
 	std::string targetAddress;
 	AudioBlock audioBlock;
+    JammerNetzChannelSetup sessionSetup;
 };
 
 #if WIN32

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -15,6 +15,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wextra-semi"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_unordered_map.h"

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -67,6 +67,7 @@ if (MSVC)
 else()
     # lots of warnings and all warnings as errors
     #target_compile_options(JammerCommon PRIVATE -Wall -Wextra -pedantic -Werror)
+    target_compile_options(JammerCommon PRIVATE -Werror)
 endif()
 
 # Define tests

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FLATBUFFER_INPUT
 		JammerNetzAudioData.fbs
 		JammerNetzChannelSetup.fbs
 		JammerNetzSessionInfo.fbs
+		JammerNetzControlMessage.fbs
 		)
 FLATBUFFERS_GENERATE_C_HEADERS(FlatJammer ${FLATBUFFER_INPUT})
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -19,7 +19,13 @@ IF (WIN32)
 ELSE()
     set(FLATBUFFERS_FLATC_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/../third_party/flatbuffers/LinuxBuilds/flatc")
 ENDIF()
-FLATBUFFERS_GENERATE_C_HEADERS(FlatJammer JammerNetzPackages.fbs JammerNetzAudioData.fbs)
+set(FLATBUFFER_INPUT
+		JammerNetzPackages.fbs
+		JammerNetzAudioData.fbs
+		JammerNetzChannelSetup.fbs
+		JammerNetzSessionInfo.fbs
+		)
+FLATBUFFERS_GENERATE_C_HEADERS(FlatJammer ${FLATBUFFER_INPUT})
 
 # Define the sources for the static library
 set(Sources
@@ -28,9 +34,8 @@ set(Sources
 	Encryption.cpp Encryption.h
 	JammerNetzClientInfoMessage.cpp JammerNetzClientInfoMessage.h
 	JammerNetzPackage.cpp JammerNetzPackage.h
-	JammerNetzPackages.fbs
-	JammerNetzAudioData.fbs
 	JuceHeader.h
+	${FLATBUFFER_INPUT}
 	${FlatJammer_OUTPUTS}
 	PacketStreamQueue.cpp PacketStreamQueue.h
 	Pool.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -66,8 +66,7 @@ if (MSVC)
     target_compile_options(JammerCommon PRIVATE /W4 /WX)
 else()
     # lots of warnings and all warnings as errors
-    #target_compile_options(JammerCommon PRIVATE -Wall -Wextra -pedantic -Werror)
-    target_compile_options(JammerCommon PRIVATE -Werror)
+    target_compile_options(JammerCommon PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
 
 # Define tests

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -36,7 +36,6 @@ set(Sources
 	JammerNetzPackage.cpp JammerNetzPackage.h
 	JuceHeader.h
 	${FLATBUFFER_INPUT}
-	${FlatJammer_OUTPUTS}
 	PacketStreamQueue.cpp PacketStreamQueue.h
 	Pool.h
 	Recorder.cpp Recorder.h
@@ -46,9 +45,13 @@ set(Sources
 	ServerInfo.cpp ServerInfo.h
 	XPlatformUtils.h
 )
-
 # Setup library
 add_library(JammerCommon ${Sources})
+foreach(OPT ${FlatJammer_OUTPUTS})
+	message("Adding source file ${OPT}")
+target_sources(JammerCommon PRIVATE ${OPT})
+endforeach()
+
 target_include_directories(JammerCommon
 	PUBLIC "${INTEL_TBB_DIRECTORY}/include/" "${CMAKE_CURRENT_LIST_DIR}/../third_party/flatbuffers/include" "${CMAKE_CURRENT_BINARY_DIR}"
 	INTERFACE ${CMAKE_CURRENT_LIST_DIR}

--- a/common/JammerNetzAudioData.fbs
+++ b/common/JammerNetzAudioData.fbs
@@ -4,14 +4,7 @@
 //   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
 //
 
-table JammerNetzPNPChannelSetup {
-	target :uint8;
-	volume :float;
-	mag: float;
-	rms: float;
-	pitch: float;
-	name: string;
-}
+include "JammerNetzChannelSetup.fbs";
 
 table JammerNetzPNPAudioSamples {
 	audioSamples :[uint16];
@@ -27,7 +20,7 @@ table JammerNetzPNPAudioBlock {
 	sampleRate :uint16;
 	channelSetup :[JammerNetzPNPChannelSetup];
 	channels :[JammerNetzPNPAudioSamples];
-	allChannels :[JammerNetzPNPChannelSetup];
+	allChannels :[JammerNetzPNPChannelSetup] (deprecated);  // This was deprecated to reduce the size of the return package
 	wantEcho: bool = true; // True is the old behavior where the client did not have any local monitoring!
 	serverTime :uint64 = 0;
 	bpm :float = 0.0;

--- a/common/JammerNetzChannelSetup.fbs
+++ b/common/JammerNetzChannelSetup.fbs
@@ -1,0 +1,14 @@
+//
+//   Copyright (c) 2024 Christof Ruch. All rights reserved.
+//
+//   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+//
+
+table JammerNetzPNPChannelSetup {
+	target :uint8;
+	volume :float;
+	mag: float;
+	rms: float;
+	pitch: float;
+	name: string;
+}

--- a/common/JammerNetzClientInfoMessage.cpp
+++ b/common/JammerNetzClientInfoMessage.cpp
@@ -109,7 +109,7 @@ String JammerNetzClientInfoMessage::getIPAddress(uint8 clientNo) const
 
 JammerNetzStreamQualityInfo JammerNetzClientInfoMessage::getStreamQuality(uint8 clientNo) const
 {
-	JammerNetzStreamQualityInfo result{ 0 };
+	JammerNetzStreamQualityInfo result{};
 	if (clientNo < getNumClients()) {
 		return clientInfos_[clientNo].qualityInfo;
 	}

--- a/common/JammerNetzClientInfoMessage.h
+++ b/common/JammerNetzClientInfoMessage.h
@@ -19,23 +19,23 @@
 
 struct JammerNetzStreamQualityInfo {
 	// Unhealed problems
-	uint64_t tooLateOrDuplicate;
-	int64_t droppedPacketCounter;
+	uint64_t tooLateOrDuplicate{};
+	int64_t droppedPacketCounter{};
 
 	// Healed problems
-	int64_t outOfOrderPacketCounter;
-	int64_t duplicatePacketCounter;
-	uint64_t dropsHealed;
+	int64_t outOfOrderPacketCounter{};
+	int64_t duplicatePacketCounter{};
+	uint64_t dropsHealed{};
 
 	// Pure statistics
-	uint64_t packagesPushed;
-	uint64_t packagesPopped;
-	uint64_t maxLengthOfGap;
-	uint64_t maxWrongOrderSpan;
+	uint64_t packagesPushed{};
+	uint64_t packagesPopped{};
+	uint64_t maxLengthOfGap{};
+	uint64_t maxWrongOrderSpan{};
 
-	double wallClockDelta;
-	double jitterMeanMillis;
-	double jitterSDMillis;
+	double wallClockDelta{};
+	double jitterMeanMillis{};
+	double jitterSDMillis{};
 };
 
 struct JammerNetzClientInfo {

--- a/common/JammerNetzClientInfoMessage.h
+++ b/common/JammerNetzClientInfoMessage.h
@@ -8,6 +8,8 @@
 
 #include "JammerNetzPackage.h"
 
+#include <vector>
+
 /*
   | CLIENTINFO type message - these are sent only by the server to the clients
   | JammerNetzClientInfoMessage

--- a/common/JammerNetzControlMessage.fbs
+++ b/common/JammerNetzControlMessage.fbs
@@ -1,0 +1,11 @@
+//
+//   Copyright (c) 2024 Christof Ruch. All rights reserved.
+//
+//   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+//
+
+table JammerNetzControlInfo {
+	control_message_json: string;
+}
+
+root_type JammerNetzControlInfo;

--- a/common/JammerNetzPackage.cpp
+++ b/common/JammerNetzPackage.cpp
@@ -11,12 +11,12 @@
 #include "JammerNetzClientInfoMessage.h"
 
 JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup() :
-	target(JammerNetzChannelTarget::Mono), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f)
+	target(JammerNetzChannelTarget::Mono), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f), name("")
 {
 }
 
 JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup(uint8 target_) :
-	target(target_), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f)
+	target(target_), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f), name("")
 {
 }
 
@@ -59,7 +59,7 @@ AudioBlock::AudioBlock(double timestamp_, uint64 messageCounter_, uint64 serverT
 std::shared_ptr<JammerNetzMessage> JammerNetzMessage::deserialize(uint8 *data, size_t bytes)
 {
 	if (bytes >= sizeof(JammerNetzHeader)) {
-		JammerNetzHeader *header = reinterpret_cast<JammerNetzHeader*>(data);
+		auto header = reinterpret_cast<JammerNetzHeader*>(data);
 
 		try {
 			// Check the magic
@@ -71,6 +71,8 @@ std::shared_ptr<JammerNetzMessage> JammerNetzMessage::deserialize(uint8 *data, s
 					return std::make_shared<JammerNetzClientInfoMessage>(data, bytes);
                 case SESSIONSETUP:
                     return std::make_shared<JammerNetzSessionInfoMessage>(data, bytes);
+                case GENERIC_JSON:
+                    return std::make_shared<JammerNetzControlMessage>(data, bytes);
 				default:
 					std::cerr << "Unknown message type received, ignoring it" << std::endl;
 				}

--- a/common/JammerNetzPackage.cpp
+++ b/common/JammerNetzPackage.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<AudioBlock> JammerNetzAudioData::readAudioHeaderAndBytes(JammerN
 	result->sampleRate = 48000;
 	size_t upsampleRate = block->sampleRate() != 0 ? 48000 / block->sampleRate() : 48000;
 	jassert(block->numberOfSamples() * upsampleRate == SAMPLE_BUFFER_SIZE);
-	result->audioBuffer = std::make_shared<AudioBuffer<float>>(block->numChannels(), block->numberOfSamples() * upsampleRate);
+	result->audioBuffer = std::make_shared<AudioBuffer<float>>((int) block->numChannels(), (int) (block->numberOfSamples() * upsampleRate));
 	readAudioBytes(block->channels(), result->audioBuffer, upsampleRate);
 	return result;
 }

--- a/common/JammerNetzPackage.cpp
+++ b/common/JammerNetzPackage.cpp
@@ -15,8 +15,8 @@ JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup() :
 {
 }
 
-JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup(uint8 target) :
-	target(target), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f)
+JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup(uint8 target_) :
+	target(target_), volume(1.0f), mag(0.0f), rms(0.0f), pitch(0.0f)
 {
 }
 
@@ -44,24 +44,15 @@ bool JammerNetzChannelSetup::isEqualEnough(const JammerNetzChannelSetup &other) 
 {
 	if (isLocalMonitoringDontSendEcho != other.isLocalMonitoringDontSendEcho) return false;
 	if (channels.size() != other.channels.size()) return false;
-	for (int i = 0; i < channels.size(); i++) {
+	for (size_t i = 0; i < channels.size(); i++) {
 		if (!(channels[i].isEqualEnough(other.channels[i]))) return false;
 	}
 	return true;
 }
 
-/*bool JammerNetzChannelSetup::operator==(const JammerNetzChannelSetup &other) const
-{
-	if (channels.size() != other.channels.size()) return false;
-	for (int i = 0; i < channels.size(); i++) {
-		if (!(channels[i] == other.channels[i])) return false;
-	}
-	return true;
-}*/
-
-AudioBlock::AudioBlock(double timestamp, uint64 messageCounter, uint64 serverTime, float bpm, MidiSignal midiSignal, uint16 sampleRate, JammerNetzChannelSetup const &channelSetup,
-                       std::shared_ptr<AudioBuffer<float>> audioBuffer, JammerNetzChannelSetup const &sessionSetup) :
-	timestamp(timestamp), messageCounter(messageCounter), serverTime(serverTime), bpm(bpm), midiSignal(midiSignal), sampleRate(sampleRate), channelSetup(channelSetup), audioBuffer(audioBuffer), sessionSetup(sessionSetup)
+AudioBlock::AudioBlock(double timestamp_, uint64 messageCounter_, uint64 serverTime_, float bpm_, MidiSignal midiSignal_, uint16 sampleRate_, JammerNetzChannelSetup const &channelSetup_,
+                       std::shared_ptr<AudioBuffer<float>> audioBuffer_) :
+	timestamp(timestamp_), messageCounter(messageCounter_), serverTime(serverTime_), bpm(bpm_), midiSignal(midiSignal_), sampleRate(sampleRate_), channelSetup(channelSetup_), audioBuffer(audioBuffer_)
 {
 }
 
@@ -78,6 +69,8 @@ std::shared_ptr<JammerNetzMessage> JammerNetzMessage::deserialize(uint8 *data, s
 					return std::make_shared<JammerNetzAudioData>(data, bytes);
 				case CLIENTINFO:
 					return std::make_shared<JammerNetzClientInfoMessage>(data, bytes);
+                case SESSIONSETUP:
+                    return std::make_shared<JammerNetzSessionInfoMessage>(data, bytes);
 				default:
 					std::cerr << "Unknown message type received, ignoring it" << std::endl;
 				}
@@ -91,7 +84,7 @@ std::shared_ptr<JammerNetzMessage> JammerNetzMessage::deserialize(uint8 *data, s
 	return nullptr;;
 }
 
-int JammerNetzMessage::writeHeader(uint8 *output, uint8 messageType) const
+size_t JammerNetzMessage::writeHeader(uint8 *output, uint8 messageType) const
 {
 	JammerNetzHeader *header = reinterpret_cast<JammerNetzHeader*>(output);
 	header->magic0 = '1';
@@ -212,13 +205,7 @@ flatbuffers::Offset<JammerNetzPNPAudioBlock> JammerNetzAudioData::serializeAudio
 		auto fb_name = fbb.CreateString(channel.name);
 		channelSetup.push_back(CreateJammerNetzPNPChannelSetup(fbb, channel.target, channel.volume, channel.mag, channel.rms, channel.pitch, fb_name));
 	}
-	std::vector<flatbuffers::Offset<JammerNetzPNPChannelSetup>> sessionChannels;
-	for (const auto& channel : src->sessionSetup.channels) {
-		auto fb_name = fbb.CreateString(channel.name);
-		sessionChannels.push_back(CreateJammerNetzPNPChannelSetup(fbb, channel.target, channel.volume, channel.mag, channel.rms, channel.pitch, fb_name));
-	}
 	auto channelSetupVector = fbb.CreateVector(channelSetup);
-	auto sessionSetupVector = fbb.CreateVector(sessionChannels);
 	auto audioSamples = appendAudioBuffer(fbb, *src->audioBuffer, reductionFactor);
 
 	JammerNetzPNPAudioBlockBuilder audioBlock(fbb);
@@ -232,7 +219,6 @@ flatbuffers::Offset<JammerNetzPNPAudioBlock> JammerNetzAudioData::serializeAudio
 	audioBlock.add_sampleRate(sampleRate / reductionFactor);
 	audioBlock.add_channelSetup(channelSetupVector);
 	audioBlock.add_channels(audioSamples);
-	audioBlock.add_allChannels(sessionSetupVector);
 	audioBlock.add_wantEcho(!src->channelSetup.isLocalMonitoringDontSendEcho);
 
 	return audioBlock.Finish();
@@ -304,11 +290,6 @@ JammerNetzChannelSetup JammerNetzAudioData::channelSetup() const
 	return activeBlock_->channelSetup;
 }
 
-JammerNetzChannelSetup JammerNetzAudioData::sessionSetup() const
-{
-	return activeBlock_->sessionSetup;
-}
-
 std::shared_ptr<AudioBlock> JammerNetzAudioData::readAudioHeaderAndBytes(JammerNetzPNPAudioBlock const *block) {
 	auto result = std::make_shared<AudioBlock>();
 
@@ -325,18 +306,7 @@ std::shared_ptr<AudioBlock> JammerNetzAudioData::readAudioHeaderAndBytes(JammerN
 		setup.pitch = channel->pitch();
 		setup.name = channel->name()->str();
 		result->channelSetup.channels.push_back(setup);
-	};
-
-	result->sessionSetup.isLocalMonitoringDontSendEcho = !block->wantEcho();
-	for (auto channel = block->allChannels()->cbegin(); channel != block->allChannels()->cend(); channel++) {
-		JammerNetzSingleChannelSetup setup(channel->target());
-		setup.volume = channel->volume();
-		setup.mag = channel->mag();
-		setup.rms = channel->rms();
-		setup.pitch = channel->pitch();
-		setup.name = channel->name()->str();
-		result->sessionSetup.channels.push_back(setup);
-	};
+	}
 
 	result->sampleRate = 48000;
 	int upsampleRate = block->sampleRate() != 0 ? 48000 / block->sampleRate() : 48000;

--- a/common/JammerNetzPackage.cpp
+++ b/common/JammerNetzPackage.cpp
@@ -23,7 +23,7 @@ JammerNetzSingleChannelSetup::JammerNetzSingleChannelSetup(uint8 target_) :
 
 bool JammerNetzSingleChannelSetup::isEqualEnough(const JammerNetzSingleChannelSetup &other) const
 {
-	return target == other.target && volume == other.volume && name == other.name;
+	return target == other.target && fabs(volume-other.volume) < 1e-6f && name == other.name;
 }
 
 /*bool JammerNetzSingleChannelSetup::operator==(const JammerNetzSingleChannelSetup &other) const
@@ -241,7 +241,7 @@ flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSa
 			float tempBuffer[MAXFRAMESIZE];
 			const float* read = buffer.getReadPointer(inputChannel);
 
-			long outputSamples = buffer.getNumSamples() / 2;
+			int outputSamples = buffer.getNumSamples() / 2;
 			for (int i = 0; i < buffer.getNumSamples(); i += reductionFactor) {
 				tempBuffer[i / reductionFactor] = read[i];
 			}
@@ -311,14 +311,14 @@ std::shared_ptr<AudioBlock> JammerNetzAudioData::readAudioHeaderAndBytes(JammerN
 	}
 
 	result->sampleRate = 48000;
-	int upsampleRate = block->sampleRate() != 0 ? 48000 / block->sampleRate() : 48000;
+	size_t upsampleRate = block->sampleRate() != 0 ? 48000 / block->sampleRate() : 48000;
 	jassert(block->numberOfSamples() * upsampleRate == SAMPLE_BUFFER_SIZE);
 	result->audioBuffer = std::make_shared<AudioBuffer<float>>(block->numChannels(), block->numberOfSamples() * upsampleRate);
 	readAudioBytes(block->channels(), result->audioBuffer, upsampleRate);
 	return result;
 }
 
-void JammerNetzAudioData::readAudioBytes(flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSamples>> const *samples, std::shared_ptr<AudioBuffer<float>> destBuffer, int upsampleRate) {
+void JammerNetzAudioData::readAudioBytes(flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSamples>> const *samples, std::shared_ptr<AudioBuffer<float>> destBuffer, size_t upsampleRate) {
 	int c = 0;
 	for (auto channel = samples->cbegin(); channel != samples->cend(); channel++) {
 		//TODO we might not have enough bytes in the package for this operation
@@ -332,7 +332,7 @@ void JammerNetzAudioData::readAudioBytes(flatbuffers::Vector<flatbuffers::Offset
 				AudioData::LittleEndian,
 				AudioData::NonInterleaved,
 				AudioData::NonConst> dst_pointer(destBuffer->getWritePointer(c));
-			dst_pointer.convertSamples(src_pointer, channel->audioSamples()->size());
+			dst_pointer.convertSamples(src_pointer, (int) channel->audioSamples()->size());
 		}
 		else {
 			float tempBuffer[MAXFRAMESIZE];
@@ -344,11 +344,11 @@ void JammerNetzAudioData::readAudioBytes(flatbuffers::Vector<flatbuffers::Offset
 				AudioData::LittleEndian,
 				AudioData::NonInterleaved,
 				AudioData::NonConst> dst_pointer(tempBuffer);
-			dst_pointer.convertSamples(src_pointer, channel->audioSamples()->size());
+			dst_pointer.convertSamples(src_pointer, (int) channel->audioSamples()->size());
 
 			auto write = destBuffer->getWritePointer(c);
 			for (size_t i = 0; i < channel->audioSamples()->size(); i++) {
-				for (int j = 0; j < upsampleRate; j++) {
+				for (size_t j = 0; j < upsampleRate; j++) {
 					write[i * upsampleRate + j] = tempBuffer[i];
 				}
 			}

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -147,7 +147,7 @@ public:
 
     // Generic deserialization constructor
     JammerNetzFlatbufferMessage(size_t size) {
-        if (size < sizeof(JammerNetzAudioHeader)) {
+        if (size < sizeof(JammerNetzHeader)) {
             throw JammerNetzMessageParseException();
         }
     }

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -154,7 +154,7 @@ public:
 
     void serialize(uint8 *output, size_t &byteswritten) const override
     {
-        byteswritten = writeHeader(output, getType());
+        byteswritten = writeHeader(output, static_cast<uint8>(getType()));
         flatbuffers::FlatBufferBuilder fbb;
         serializeToFlatbuffer(fbb);
         memcpy(output + byteswritten, fbb.GetBufferPointer(), fbb.GetSize());
@@ -184,7 +184,7 @@ public:
             try {
                 json_ = nlohmann::json::parse(buffer->control_message_json()->str());
             }
-            catch (nlohmann::json::parse_error &e) {
+            catch (nlohmann::json::parse_error &) {
                 throw JammerNetzMessageParseException();
             }
         }

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -13,6 +13,8 @@
 #include "JammerNetzSessionInfo_generated.h"
 #include "JammerNetzControlMessage_generated.h"
 
+#include <string>
+#include <vector>
 
 const size_t MAXFRAMESIZE = 65536;
 
@@ -47,7 +49,7 @@ enum JammerNetzChannelTarget {
 
 struct JammerNetzSingleChannelSetup {
 	JammerNetzSingleChannelSetup();
-	JammerNetzSingleChannelSetup(uint8 target);
+	explicit JammerNetzSingleChannelSetup(uint8 target);
 	uint8 target;
 	float volume;
 	float mag;
@@ -55,27 +57,25 @@ struct JammerNetzSingleChannelSetup {
 	float pitch;
 	std::string name;
 
-	bool isEqualEnough(const JammerNetzSingleChannelSetup &other) const;
-	//bool operator ==(const JammerNetzSingleChannelSetup &other) const;
+	[[nodiscard]] bool isEqualEnough(const JammerNetzSingleChannelSetup &other) const;
 };
 
 struct JammerNetzChannelSetup {
-	JammerNetzChannelSetup(bool localMonitoring);
+	explicit JammerNetzChannelSetup(bool localMonitoring);
 	JammerNetzChannelSetup(bool localMonitoring, std::vector<JammerNetzSingleChannelSetup> const &channelInfo);
 	bool isLocalMonitoringDontSendEcho;
 	std::vector<JammerNetzSingleChannelSetup> channels;
 
-	bool isEqualEnough(const JammerNetzChannelSetup &other) const;
-	//bool operator ==(const JammerNetzChannelSetup &other) const;
+	[[nodiscard]] bool isEqualEnough(const JammerNetzChannelSetup &other) const;
 };
 
 struct JammerNetzAudioBlock {
-	double timestamp; // Using JUCE's high resolution timer
-	juce::uint64 messageCounter;
+	double timestamp{}; // Using JUCE's high resolution timer
+	juce::uint64 messageCounter{};
 	JammerNetzChannelSetup channelSetup;
-	uint8 numchannels;
-	uint16 numberOfSamples;
-	uint16 sampleRate;
+	uint8 numchannels{};
+	uint16 numberOfSamples{};
+	uint16 sampleRate{};
 };
 
 struct JammerNetzAudioHeader {

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -262,7 +262,7 @@ private:
 	flatbuffers::Offset<JammerNetzPNPAudioBlock> serializeAudioBlock(flatbuffers::FlatBufferBuilder &fbb, std::shared_ptr<AudioBlock> src, uint16 sampleRate, uint16 reductionFactor) const;
 	flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSamples>>> appendAudioBuffer(flatbuffers::FlatBufferBuilder &fbb, AudioBuffer<float> &buffer, uint16 reductionFactor) const;
 	std::shared_ptr<AudioBlock> readAudioHeaderAndBytes(JammerNetzPNPAudioBlock const *block);
-	void readAudioBytes(flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSamples >> const *samples, std::shared_ptr<AudioBuffer<float>> destBuffer, int upsampleRate);
+	void readAudioBytes(flatbuffers::Vector<flatbuffers::Offset<JammerNetzPNPAudioSamples >> const *samples, std::shared_ptr<AudioBuffer<float>> destBuffer, size_t upsampleRate);
 
 	std::shared_ptr<AudioBlock> audioBlock_;
 	std::shared_ptr<AudioBlock> fecBlock_;

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -8,13 +8,14 @@
 
 #include "JuceHeader.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
-
+#endif
 #include "flatbuffers/flatbuffers.h"
-
+#ifdef __clang__
 #pragma clang diagnostic pop
-
+#endif
 
 #include "JammerNetzAudioData_generated.h"
 #include "JammerNetzSessionInfo_generated.h"

--- a/common/JammerNetzPackage.h
+++ b/common/JammerNetzPackage.h
@@ -8,13 +8,13 @@
 
 #include "JuceHeader.h"
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 #include "flatbuffers/flatbuffers.h"
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif
 
 #include "JammerNetzAudioData_generated.h"

--- a/common/JammerNetzSessionInfo.fbs
+++ b/common/JammerNetzSessionInfo.fbs
@@ -1,0 +1,15 @@
+//
+//   Copyright (c) 2024 Christof Ruch. All rights reserved.
+//
+//   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+//
+
+include "JammerNetzChannelSetup.fbs";
+
+table JammerNetzSessionInfo {
+	allChannels :[JammerNetzPNPChannelSetup];
+}
+
+root_type JammerNetzSessionInfo;
+
+

--- a/common/PacketStreamQueue.cpp
+++ b/common/PacketStreamQueue.cpp
@@ -6,7 +6,10 @@
 
 #include "PacketStreamQueue.h"
 
-PacketStreamQueue::PacketStreamQueue(std::string const &streamName) : lastPoppedMessage_(0), lastPushedMessage_(0), currentGap_(0)
+PacketStreamQueue::PacketStreamQueue(std::string const &streamName) :
+    lastPushedMessage_(0)
+    , lastPoppedMessage_(0)
+    , currentGap_(0)
 {
 	qualityData_.streamName = streamName;
 }

--- a/common/PacketStreamQueue.h
+++ b/common/PacketStreamQueue.h
@@ -11,8 +11,13 @@
 #include "JammerNetzPackage.h"
 #include "JammerNetzClientInfoMessage.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
 #include "tbb/concurrent_hash_map.h"
 #include "tbb/concurrent_priority_queue.h"
+
+#pragma clang diagnostic pop
 
 #include "RunningStats.h"
 

--- a/common/PacketStreamQueue.h
+++ b/common/PacketStreamQueue.h
@@ -14,6 +14,7 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 #include "tbb/concurrent_hash_map.h"
 #include "tbb/concurrent_priority_queue.h"

--- a/common/PacketStreamQueue.h
+++ b/common/PacketStreamQueue.h
@@ -11,14 +11,15 @@
 #include "JammerNetzPackage.h"
 #include "JammerNetzClientInfoMessage.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"
-
+#endif
 #include "tbb/concurrent_hash_map.h"
 #include "tbb/concurrent_priority_queue.h"
-
+#ifdef __clang__
 #pragma clang diagnostic pop
-
+#endif
 #include "RunningStats.h"
 
 

--- a/common/PacketStreamQueue.h
+++ b/common/PacketStreamQueue.h
@@ -11,14 +11,14 @@
 #include "JammerNetzPackage.h"
 #include "JammerNetzClientInfoMessage.h"
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #include "tbb/concurrent_hash_map.h"
 #include "tbb/concurrent_priority_queue.h"
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif
 #include "RunningStats.h"
 

--- a/common/Pool.h
+++ b/common/Pool.h
@@ -36,7 +36,7 @@ class Pool
             }
         }
         auto it = free_m.begin();
-        std::shared_ptr<T> sptr( it->get(), [=](T* ptr){ this->free(ptr); } );
+        std::shared_ptr<T> sptr( it->get(), [this](T* ptr){ this->free(ptr); } );
         used_m.push_front(std::move(*it));
         free_m.erase(it);
         return sptr;

--- a/common/Recorder.cpp
+++ b/common/Recorder.cpp
@@ -7,7 +7,13 @@
 #include "Recorder.h"
 
 Recorder::Recorder(File directory, std::string const &baseFileName, RecordingType recordingType)
-	: directory_(directory), baseFileName_(baseFileName), writer_(nullptr), recordingType_(recordingType), samplesWritten_(0), lastChannelSetup_(false)
+	:
+     samplesWritten_(0)
+    , directory_(directory)
+    , baseFileName_(baseFileName)
+    , recordingType_(recordingType)
+    , writer_(nullptr)
+    , lastChannelSetup_(false)
 {
 	thread_ = std::make_unique<TimeSliceThread>("RecorderDiskWriter");
 	thread_->startThread();
@@ -95,7 +101,7 @@ void Recorder::updateChannelInfo(int sampleRate, JammerNetzChannelSetup const &c
 
 	// Setup the channel layout
 	AudioChannelSet channels;
-	int numChannels = 0;
+	unsigned numChannels = 0;
 	for (auto channel : channelSetup.channels) {
 		switch (channel.target) {
 		case Mute:
@@ -152,12 +158,12 @@ void Recorder::launchWriter() {
 
 void Recorder::saveBlock(const float* const* data, int numSamples) {
 	// Don't crash on me when there is surprisingly no data in the package
-	if (data && data[0]) {
+	if (data && data[0] && numSamples > 0) {
 		if (!writeThread_->write(data, numSamples)) {
 			//TODO - need a smarter strategy than that
 			std::cerr << "Ups, FIFO full and can't write block to disk, lost it!" << std::endl;
 		}
-		samplesWritten_ += numSamples;
+		samplesWritten_ += (size_t) numSamples;
 	}
 }
 

--- a/common/Recorder.cpp
+++ b/common/Recorder.cpp
@@ -163,7 +163,7 @@ void Recorder::saveBlock(const float* const* data, int numSamples) {
 			//TODO - need a smarter strategy than that
 			std::cerr << "Ups, FIFO full and can't write block to disk, lost it!" << std::endl;
 		}
-		samplesWritten_ += (size_t) numSamples;
+		samplesWritten_ += (juce::uint64) numSamples;
 	}
 }
 

--- a/common/RingOfAudioBuffers.h
+++ b/common/RingOfAudioBuffers.h
@@ -24,7 +24,11 @@ public:
 
 	void push(std::shared_ptr<T> audioBuffer) {
 		// The write pointer always points to the next element to write to
-		data_[endIndex_] = audioBuffer;
+        if (endIndex_ < 0) {
+            jassertfalse;
+            return;
+        }
+		data_[(size_t) endIndex_] = audioBuffer;
 		incIndex(endIndex_);
 		if (endIndex_ == headIndex_) {
 			incIndex(headIndex_);
@@ -39,7 +43,7 @@ public:
 
 		int readIndex = endIndex_ - 1;
 		if (readIndex < 0) readIndex += (int) data_.size();
-		return data_[readIndex];
+		return data_[(size_t) readIndex];
 	}
 
 	std::shared_ptr<T> getNthLast(int n) const
@@ -62,13 +66,13 @@ public:
 			if (readIndex < 0) readIndex += (int) data_.size();
 			count++;
 		}
-		return data_[readIndex];
+		return data_[(size_t) readIndex];
 	}
 
 private:
 	void incIndex(int &index)
 	{
-		index = (index + 1) % data_.size();
+		index = (index + 1) % (int) data_.size();
 	}
 
 	std::vector<std::shared_ptr<T>> data_;


### PR DESCRIPTION
… each audio block, because that increases the block size of the audio stream a lot when more participants join the session. It might even increase the block size beyond the maximum frame size, which makes the audio go kaputt. Instead, send a separate package with a reduced frame rate to the other clients. This makes the peak meteres be less real time, but it saves a lot in terms of audio package size and allows us to turn on FEC again!