### PR TITLE
Remove unneeded Linux deps.

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -19,8 +19,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y g++ cmake libncurses-dev libglew-dev libncurses5-dev nlohmann-json3-dev
-        sudo apt-get install -y libcurl4-openssl-dev pkg-config libasound2-dev libgtk-3-dev libglew-dev libjack-dev
-        sudo apt-get install -y libasound2-dev libjack-jackd2-dev ladspa-sdk libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev mesa-common-dev
+        sudo apt-get install -y libcurl4-openssl-dev pkg-config libasound2-dev libjack-dev
+        sudo apt-get install -y libasound2-dev libjack-jackd2-dev ladspa-sdk libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libglu1-mesa-dev mesa-common-dev
 
     - name: Build Flatbuffers and Sentry
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,6 @@ elseif(UNIX)
 	# Include useful scripts for CMake
 	find_package(PkgConfig REQUIRED)
 	find_package(OpenGL)
-
-	# These calls create special `PkgConfig::<MODULE>` variables
-	if(BUILD_JAMMERNETZ_CLIENT)
-		pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
-		pkg_check_modules(GLEW REQUIRED IMPORTED_TARGET glew)
-		pkg_check_modules(WEBKIT REQUIRED IMPORTED_TARGET webkit2gtk-4.1)
-	endif()
 endif()
 
 
@@ -115,17 +108,9 @@ mark_as_advanced(
 
 # Define the list of link libraries required on Linux linking with JUCE, this must be used by any executable / module to run standalone
 if(UNIX AND NOT APPLE)
-	if(BUILD_JAMMERNETZ_CLIENT)
-		set(LINUX_UI_LIBRARIES
-		PkgConfig::WEBKIT
-		PkgConfig::GTK
-		PkgConfig::GLEW
-		)
-	endif()
 	set(LINUX_JUCE_LINK_LIBRARIES
 		Xext
 		X11
-		${LINUX_UI_LIBRARIES}
 		pthread
 		${CMAKE_DL_LIBS}
 		freetype
@@ -166,6 +151,7 @@ target_link_libraries(juce-static
 
 target_compile_definitions(juce-static
 	PUBLIC
+		JUCE_WEB_BROWSER=0
 		JUCE_PLUGINHOST_VST=0
 		JUCE_PLUGINHOST_AU=0
 		DONT_SET_USING_JUCE_NAMESPACE=1

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -138,9 +138,6 @@ ELSE()
 	target_link_libraries(JammerNetzClient
 		${JUCE_LIBRARIES}
 		${DS_LIBRARIES}
-		PkgConfig::WEBKIT
-		PkgConfig::GTK
-		PkgConfig::GLEW
 		Xext
 		X11
 		pthread


### PR DESCRIPTION
These libraries aren't needing.
This also should reduce runtime dependencies for the binaries.