### PR TITLE
Validate macOS target and disk space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X version to ta
 
 project(JammerNetz)
 
+if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.12")
+	message(FATAL_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET must be 10.12 or newer (got '${CMAKE_OSX_DEPLOYMENT_TARGET}')")
+endif()
+
 OPTION(BUILD_JAMMERNETZ_CLIENT "Option to turn off the client build" ON)
 OPTION(JAMMERNETZ_ENABLE_LTO "Enable JUCE LTO flags (better runtime performance, slower links)" OFF)
 

--- a/Client/Source/RecordingInfo.cpp
+++ b/Client/Source/RecordingInfo.cpp
@@ -128,12 +128,13 @@ void RecordingInfo::updateData()
 	if (recorder_.lock()) {
 		auto dir = recorder_.lock()->getDirectory();
 		recordingPath_.setText(dir.getFullPathName(), dontSendNotification);
-		const auto freeBytes = dir.getBytesFreeOnVolume();
+		const auto reportedFreeBytes = dir.getBytesFreeOnVolume();
+		const auto freeBytes = reportedFreeBytes > 0 ? reportedFreeBytes : 0;
 		const auto totalBytes = dir.getVolumeTotalSize();
 		diskSpacePercentage_ = totalBytes > 0
 			? 1.0 - static_cast<double>(freeBytes) / static_cast<double>(totalBytes)
 			: 0.0;
-		diskSpace_.setTextToDisplay(humanReadableByteCount(freeBytes > 0 ? static_cast<size_t>(freeBytes) : size_t{0}, false));
+		diskSpace_.setTextToDisplay(humanReadableByteCount(static_cast<size_t>(freeBytes), false));
 		bool isLive = recorder_.lock()->isRecording();
 		recording_.setToggleState(!isLive, dontSendNotification);
 


### PR DESCRIPTION
## Summary
- normalize negative reported free-space values before calculating and displaying disk usage
- reject effective macOS deployment targets below 10.12 while preserving the 10.12 default and higher overrides

## Validation
- git diff --check
- Darwin CMake configure with 10.11 fails at the new deployment-target check
- Darwin CMake configure with 10.12 passes the check and continues into dependency configuration

This is a focused follow-up to #51.