### PR TITLE
Fix server client disconnect races

### DIFF
--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 set(SOURCES
 	Source/Main.cpp
+	Source/ClientState.cpp Source/ClientState.h
 	Source/AcceptThread.cpp Source/AcceptThread.h
 	Source/MixerThread.cpp Source/MixerThread.h
 	Source/SendThread.cpp Source/SendThread.h
@@ -33,6 +34,15 @@ if(SENTRY_CRASH_REPORTING)
 	message(STATUS "Configuring server to link with ${SENTRY_INSTALL_PATH}/lib")
 	target_link_directories(JammerNetzServer PRIVATE "${SENTRY_INSTALL_PATH}/lib")
 endif()
+
+add_executable(ClientStateTest Source/ClientStateTests.cpp Source/ClientState.cpp Source/ClientState.h Source/SharedServerTypes.h)
+target_include_directories(ClientStateTest PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Source")
+target_link_libraries(ClientStateTest PRIVATE gtest gmock gtest_main juce-utils JammerCommon ${JUCE_LIBRARIES})
+gtest_discover_tests(ClientStateTest
+	WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY}
+	PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${TEST_WORKING_DIRECTORY}"
+)
+set_target_properties(ClientStateTest PROPERTIES FOLDER tests)
 if (WIN32)
 	target_link_libraries(JammerNetzServer  ${JUCE_LIBRARIES} juce-utils JammerCommon pdcurses::pdcurses ${SENTRY_LIB})
 

--- a/Server/Source/AcceptThread.cpp
+++ b/Server/Source/AcceptThread.cpp
@@ -8,7 +8,7 @@
 
 #include "BuffersConfig.h"
 
-#include <stack>
+#include <algorithm>
 #include "ServerLogger.h"
 
 class PrintQualityTimer : public HighResolutionTimer {
@@ -19,8 +19,9 @@ public:
 	virtual void hiResTimerCallback() override
 	{
 		for (auto &streamData : data_) {
-			if (streamData.second) {
-				ServerLogger::printStatistics(4, streamData.first, streamData.second->qualityInfoPackage());
+			JammerNetzStreamQualityInfo qualityInfo;
+			if (streamData.second && streamData.second->qualityInfo(qualityInfo)) {
+				ServerLogger::printStatistics(4, streamData.first, qualityInfo);
 			}
 		}
 	}
@@ -69,36 +70,32 @@ void AcceptThread::processControlMessage(std::shared_ptr<JammerNetzControlMessag
 void AcceptThread::processAudioMessage(std::shared_ptr<JammerNetzAudioData> audioData, std::string const& clientName)
 {
     if (audioData) {
-        // Insert this package into the right priority audio queue
-        bool prefill = false;
-        if (incomingData_.find(clientName) == incomingData_.end()) {
-            // This is from a new client!
-            ServerLogger::printClientStatus(4, clientName,
-                                            "New client connected, first package received");
-            incomingData_[clientName] = std::make_unique<PacketStreamQueue>(clientName);
-            prefill = true;
-        } else if (!incomingData_[clientName]) {
-            ServerLogger::printClientStatus(4, clientName,
-                                            "Reconnected successfully and starts sending again");
-            incomingData_[clientName] = std::make_unique<PacketStreamQueue>(clientName);
-            prefill = false;
-        }
-        if (prefill) {
-            auto lastInserted = audioData;
-            std::stack<std::shared_ptr<JammerNetzAudioData>> reverse;
-            for (int i = 0; i < bufferConfig_.serverBufferPrefillOnConnect; i++) {
-                lastInserted = lastInserted->createPrePaddingPackage();
-                reverse.push(lastInserted);
-            }
-            while (!reverse.empty()) {
-                incomingData_[clientName]->push(reverse.top());
-                reverse.pop();
-            }
-        }
+		// Publish a fully constructed, stable value. Concurrent readers never observe
+		// an empty mapped smart pointer and never access queue ownership directly.
+		auto insertion = incomingData_.insert(
+			std::make_pair(clientName, std::make_shared<ClientState>(clientName)));
+		auto clientState = insertion.first->second;
+		const auto prefillCount = static_cast<std::size_t>(
+			std::max(0, bufferConfig_.serverBufferPrefillOnConnect));
+		const auto result = clientState->push(audioData, prefillCount);
 
-        if (incomingData_[clientName]->push(audioData)) {
-            // Only if this was not a duplicate package do give the mixer thread a tick, else duplicates will cause queue drain
-            wakeUpQueue_.push(
+		switch (result.transition) {
+		case ClientConnectionTransition::InitialConnection:
+			ServerLogger::printClientStatus(4, clientName, "New client connected, first package received");
+			break;
+		case ClientConnectionTransition::GraceRecovery:
+			ServerLogger::printClientStatus(4, clientName, "Client recovered during disconnect grace period");
+			break;
+		case ClientConnectionTransition::Reconnection:
+			ServerLogger::printClientStatus(4, clientName, "Reconnected successfully and starts sending again");
+			break;
+		case ClientConnectionTransition::None:
+			break;
+		}
+
+		if (result.queued) {
+			// Only if this was not a duplicate package do give the mixer thread a tick, else duplicates will cause queue drain
+			wakeUpQueue_.push(
                     1); // The value pushed is irrelevant, we just want to wake up the mixer thread which is in a blocking read on this queue
         }
     }

--- a/Server/Source/ClientState.cpp
+++ b/Server/Source/ClientState.cpp
@@ -1,0 +1,95 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "ClientState.h"
+
+#include <stack>
+#include <utility>
+
+ClientState::ClientState(std::string clientName) : clientName_(std::move(clientName)) {
+}
+
+ClientPushResult ClientState::push(std::shared_ptr<JammerNetzAudioData> packet,
+	std::size_t initialPrefillCount, TimePoint /*now*/) {
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	ClientConnectionTransition transition = ClientConnectionTransition::None;
+	const bool isInitialConnection = !hasConnected_;
+	if (!queue_) {
+		queue_ = std::make_shared<PacketStreamQueue>(clientName_);
+		transition = isInitialConnection ? ClientConnectionTransition::InitialConnection
+			: ClientConnectionTransition::Reconnection;
+	}
+	else if (state_ == ClientConnectionState::Disconnecting) {
+		transition = ClientConnectionTransition::GraceRecovery;
+	}
+
+	state_ = ClientConnectionState::Connected;
+	hasConnected_ = true;
+	++activityGeneration_;
+
+	// Preserve the existing behavior: only the first connection is prefixed with
+	// padding. A reconnect starts with the first real packet and a fresh queue.
+	if (isInitialConnection) {
+		auto lastInserted = packet;
+		std::stack<std::shared_ptr<JammerNetzAudioData>> reverse;
+		for (std::size_t i = 0; i < initialPrefillCount; ++i) {
+			lastInserted = lastInserted->createPrePaddingPackage();
+			reverse.push(lastInserted);
+		}
+		while (!reverse.empty()) {
+			queue_->push(reverse.top());
+			reverse.pop();
+		}
+	}
+
+	return {queue_->push(std::move(packet)), transition};
+}
+
+bool ClientState::tryPop(std::shared_ptr<JammerNetzAudioData> &packet, bool &isFillIn,
+	std::uint64_t &observedActivityGeneration) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	observedActivityGeneration = activityGeneration_;
+	if (state_ == ClientConnectionState::Disconnected || !queue_) {
+		return false;
+	}
+	return queue_->try_pop(packet, isFillIn);
+}
+
+ClientQueueSnapshot ClientState::snapshot() const {
+	std::lock_guard<std::mutex> lock(mutex_);
+	return {state_, state_ == ClientConnectionState::Disconnected || !queue_ ? 0 : queue_->size(),
+		activityGeneration_};
+}
+
+bool ClientState::qualityInfo(JammerNetzStreamQualityInfo &qualityInfo) const {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (state_ == ClientConnectionState::Disconnected || !queue_) {
+		return false;
+	}
+	qualityInfo = queue_->qualityInfoPackage();
+	return true;
+}
+
+bool ClientState::markUnderrun(std::uint64_t observedActivityGeneration, TimePoint now) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (state_ != ClientConnectionState::Connected || activityGeneration_ != observedActivityGeneration) {
+		return false;
+	}
+	state_ = ClientConnectionState::Disconnecting;
+	disconnectDeadline_ = now + DisconnectGracePeriod;
+	return true;
+}
+
+bool ClientState::disconnectIfGraceExpired(TimePoint now) {
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (state_ != ClientConnectionState::Disconnecting || now < disconnectDeadline_) {
+		return false;
+	}
+	state_ = ClientConnectionState::Disconnected;
+	queue_.reset();
+	return true;
+}

--- a/Server/Source/ClientState.h
+++ b/Server/Source/ClientState.h
@@ -1,0 +1,69 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "PacketStreamQueue.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+enum class ClientConnectionState {
+	Disconnected,
+	Connected,
+	Disconnecting
+};
+
+enum class ClientConnectionTransition {
+	None,
+	InitialConnection,
+	GraceRecovery,
+	Reconnection
+};
+
+struct ClientPushResult {
+	bool queued;
+	ClientConnectionTransition transition;
+};
+
+struct ClientQueueSnapshot {
+	ClientConnectionState state;
+	std::size_t size;
+	std::uint64_t activityGeneration;
+};
+
+// Owns one client's queue and connection state. Queue ownership never escapes this
+// class, so disconnect/reconnect cannot invalidate another thread's queue access.
+class ClientState {
+public:
+	using Clock = std::chrono::steady_clock;
+	using TimePoint = Clock::time_point;
+	static constexpr auto DisconnectGracePeriod = std::chrono::seconds(2);
+
+	explicit ClientState(std::string clientName);
+
+	ClientPushResult push(std::shared_ptr<JammerNetzAudioData> packet,
+		std::size_t initialPrefillCount, TimePoint now = Clock::now());
+	bool tryPop(std::shared_ptr<JammerNetzAudioData> &packet, bool &isFillIn,
+		std::uint64_t &observedActivityGeneration);
+	ClientQueueSnapshot snapshot() const;
+	bool qualityInfo(JammerNetzStreamQualityInfo &qualityInfo) const;
+
+	bool markUnderrun(std::uint64_t observedActivityGeneration, TimePoint now = Clock::now());
+	bool disconnectIfGraceExpired(TimePoint now = Clock::now());
+
+private:
+	mutable std::mutex mutex_;
+	std::string clientName_;
+	ClientConnectionState state_{ClientConnectionState::Disconnected};
+	std::shared_ptr<PacketStreamQueue> queue_;
+	TimePoint disconnectDeadline_{};
+	std::uint64_t activityGeneration_{0};
+	bool hasConnected_{false};
+};

--- a/Server/Source/ClientStateTests.cpp
+++ b/Server/Source/ClientStateTests.cpp
@@ -1,0 +1,128 @@
+#include "ClientState.h"
+#include "SharedServerTypes.h"
+
+#include "BuffersConfig.h"
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+std::shared_ptr<JammerNetzAudioData> makePacket(std::uint64_t counter) {
+	auto buffer = std::make_shared<AudioBuffer<float>>(2, SAMPLE_BUFFER_SIZE);
+	JammerNetzChannelSetup setup(false);
+	setup.channels.push_back(JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left));
+	setup.channels.push_back(JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right));
+	return std::make_shared<JammerNetzAudioData>(counter, 1234.0, setup, SAMPLE_RATE, 0.0f,
+		MidiSignal_None, buffer, nullptr);
+}
+
+TEST(ClientStateTest, CoversInitialConnectionGraceRecoveryDisconnectAndReconnect) {
+	ClientState client("127.0.0.1:1234");
+	const auto start = ClientState::TimePoint{};
+
+	auto initial = client.push(makePacket(100), 2, start);
+	EXPECT_TRUE(initial.queued);
+	EXPECT_EQ(initial.transition, ClientConnectionTransition::InitialConnection);
+	auto initialSnapshot = client.snapshot();
+	EXPECT_EQ(initialSnapshot.state, ClientConnectionState::Connected);
+	EXPECT_EQ(initialSnapshot.size, 3u);
+
+	EXPECT_TRUE(client.markUnderrun(initialSnapshot.activityGeneration, start));
+	EXPECT_EQ(client.snapshot().state, ClientConnectionState::Disconnecting);
+
+	auto recovery = client.push(makePacket(101), 2, start + std::chrono::milliseconds(500));
+	EXPECT_TRUE(recovery.queued);
+	EXPECT_EQ(recovery.transition, ClientConnectionTransition::GraceRecovery);
+	EXPECT_EQ(client.snapshot().state, ClientConnectionState::Connected);
+
+	auto recoverySnapshot = client.snapshot();
+	EXPECT_TRUE(client.markUnderrun(recoverySnapshot.activityGeneration, start + std::chrono::seconds(1)));
+	EXPECT_FALSE(client.disconnectIfGraceExpired(start + std::chrono::seconds(2)));
+	EXPECT_TRUE(client.disconnectIfGraceExpired(start + std::chrono::seconds(3)));
+	EXPECT_EQ(client.snapshot().state, ClientConnectionState::Disconnected);
+	EXPECT_EQ(client.snapshot().size, 0u);
+
+	auto reconnect = client.push(makePacket(1), 2, start + std::chrono::seconds(4));
+	EXPECT_TRUE(reconnect.queued);
+	EXPECT_EQ(reconnect.transition, ClientConnectionTransition::Reconnection);
+	EXPECT_EQ(client.snapshot().state, ClientConnectionState::Connected);
+	EXPECT_EQ(client.snapshot().size, 1u); // Reconnects intentionally do not prefill.
+}
+
+TEST(ClientStateTest, RejectsAnUnderrunDecisionMadeBeforeConcurrentPacketActivity) {
+	ClientState client("127.0.0.1:1234");
+	client.push(makePacket(100), 0);
+	const auto staleGeneration = client.snapshot().activityGeneration;
+	client.push(makePacket(101), 0);
+
+	EXPECT_FALSE(client.markUnderrun(staleGeneration));
+	EXPECT_EQ(client.snapshot().state, ClientConnectionState::Connected);
+}
+
+TEST(ClientStateTest, SupportsConcurrentPublicationMixSendAndStatisticsAccess) {
+	TPacketStreamBundle clients;
+	std::atomic<bool> accepting{true};
+	std::atomic<int> readersReady{0};
+	constexpr int clientCount = 16;
+	constexpr int packetCount = 2000;
+
+	std::thread acceptThread([&] {
+		while (readersReady.load() != 3) {
+			std::this_thread::yield();
+		}
+		for (int i = 0; i < packetCount; ++i) {
+			const auto name = "127.0.0.1:" + std::to_string(1000 + (i % clientCount));
+			auto insertion = clients.insert(std::make_pair(name, std::make_shared<ClientState>(name)));
+			insertion.first->second->push(
+				makePacket(static_cast<std::uint64_t>(100 + i / clientCount)), 0);
+		}
+		accepting = false;
+	});
+
+	std::thread mixThread([&] {
+		++readersReady;
+		while (accepting.load()) {
+			for (auto &entry : clients) {
+				std::shared_ptr<JammerNetzAudioData> packet;
+				bool isFillIn = false;
+				std::uint64_t generation = 0;
+				if (!entry.second->tryPop(packet, isFillIn, generation)) {
+					entry.second->markUnderrun(generation);
+				}
+				entry.second->disconnectIfGraceExpired();
+			}
+		}
+	});
+
+	auto inspectClients = [&] {
+		++readersReady;
+		while (accepting.load()) {
+			for (auto &entry : clients) {
+				const auto snapshot = entry.second->snapshot();
+				JammerNetzStreamQualityInfo qualityInfo;
+				if (snapshot.size > 0) {
+					entry.second->qualityInfo(qualityInfo);
+				}
+			}
+		}
+	};
+	std::thread sendThread(inspectClients);
+	std::thread statisticsThread(inspectClients);
+
+	acceptThread.join();
+	mixThread.join();
+	sendThread.join();
+	statisticsThread.join();
+
+	EXPECT_EQ(clients.size(), static_cast<std::size_t>(clientCount));
+	for (const auto &entry : clients) {
+		EXPECT_NE(entry.second, nullptr);
+	}
+}
+
+} // namespace

--- a/Server/Source/MixerThread.cpp
+++ b/Server/Source/MixerThread.cpp
@@ -38,9 +38,16 @@ void MixerThread::run() {
 		int available = 0;
 		for (auto &inqueue : incoming_) {
 			if (inqueue.second) {
+				if (inqueue.second->disconnectIfGraceExpired()) {
+					ServerLogger::printClientStatus(4, inqueue.first, "Disconnect grace period expired");
+				}
+				const auto snapshot = inqueue.second->snapshot();
+				if (snapshot.state == ClientConnectionState::Disconnected) {
+					continue;
+				}
 				clientCount++;
-				if ((int)inqueue.second->size() > bufferConfig_.serverIncomingJitterBuffer) available++;
-				if ((int)inqueue.second->size() > bufferConfig_.serverIncomingMaximumBuffer) queueOverrun = true; // This is one client much faster than the others
+				if (static_cast<int>(snapshot.size) > bufferConfig_.serverIncomingJitterBuffer) available++;
+				if (static_cast<int>(snapshot.size) > bufferConfig_.serverIncomingMaximumBuffer) queueOverrun = true; // This is one client much faster than the others
 			}
 		}
 		if (clientCount == available) allHaveDelivered = true;
@@ -49,44 +56,47 @@ void MixerThread::run() {
 
 		// Ok, we are committed now to mix the data!
 		std::map<std::string, std::shared_ptr<JammerNetzAudioData>> incomingData;
+		std::map<std::string, std::uint64_t> observedActivity;
 		// Try to pop a package from each client
 		for (auto &inqueue : incoming_) {
-			if (inqueue.second) { // Skip client entries without a queue
+			if (inqueue.second) {
 				if (incomingData.find(inqueue.first) == incomingData.end()) {
 					// That client hasn't popped yet - try it!
 					std::shared_ptr<JammerNetzAudioData> popped;
-					bool isFillIn;
-					if (inqueue.second->try_pop(popped, isFillIn)) {
+					bool isFillIn = false;
+					std::uint64_t activityGeneration = 0;
+					if (inqueue.second->tryPop(popped, isFillIn, activityGeneration)) {
 						incomingData[inqueue.first] = popped;
 						if (isFillIn) {
 							wakeUpQueue_.push(0);
 						}
 					}
+					else if (inqueue.second->snapshot().state != ClientConnectionState::Disconnected) {
+						observedActivity[inqueue.first] = activityGeneration;
+					}
 				}
 			}
 		}
 
-		// All clients who have not delivered by now are to be gone!
+		// Start a grace period for clients that have not delivered. The activity
+		// generation prevents a packet racing this decision from being ignored.
 		// While doing this, sort all session infos into a multimap with sender -> session info
 		std::multimap<std::string, JammerNetzChannelSetup> allSessionChannels;
-		std::vector<std::string> toBeRemoved;
 		for (auto inClient = incoming_.cbegin(); inClient != incoming_.cend(); inClient++) {
 			if (inClient->second) {
-				if (incomingData.find(inClient->first) == incomingData.end()) {
-					ServerLogger::printClientStatus(4, inClient->first, "Jitter queue underrun, removing from client list in mix!");
-					toBeRemoved.push_back(inClient->first);
+				auto observation = observedActivity.find(inClient->first);
+				if (observation != observedActivity.end()) {
+					if (inClient->second->markUnderrun(observation->second)) {
+						ServerLogger::printClientStatus(4, inClient->first,
+							"Jitter queue underrun, starting disconnect grace period");
+					}
 				}
-				else {
+				else if (incomingData.find(inClient->first) != incomingData.end()) {
 					// TODO- do we need to do this every packet?
 					// Is part of mix, list in session info
 					allSessionChannels.emplace(inClient->first, incomingData[inClient->first]->channelSetup());
 				}
 			}
-		}
-		for (auto remove : toBeRemoved) {
-			// Kill the queue of that client
-			//TODO - this is not thread safe. I am not allowed to remove the queue, I can only empty it and somewhere else flag the client as connected or not.
-			incoming_[remove].reset();
 		}
 
 		// All clients have delivered (or one has a timeout), mix them all together!

--- a/Server/Source/SendThread.cpp
+++ b/Server/Source/SendThread.cpp
@@ -62,11 +62,12 @@ void SendThread::sendClientInfoPackage(std::string const &targetAddress)
 	// Loop over the incoming data streams and add them to our statistics package we are going to send to the client
 	JammerNetzClientInfoMessage clientInfoPackage;
 	for (auto &incoming : incomingData_) {
-		if (incoming.second && incoming.second->size() > 0) {
+		JammerNetzStreamQualityInfo qualityInfo;
+		if (incoming.second && incoming.second->snapshot().size > 0 && incoming.second->qualityInfo(qualityInfo)) {
 			String ipAddress;
 			int port;
 			determineTargetIP(incoming.first, ipAddress, port);
-			clientInfoPackage.addClientInfo(IPAddress(ipAddress), port, incoming.second->qualityInfoPackage());
+			clientInfoPackage.addClientInfo(IPAddress(ipAddress), port, qualityInfo);
 		}
 	}
 	if (clientInfoPackage.getNumClients() == 0) {

--- a/Server/Source/SharedServerTypes.h
+++ b/Server/Source/SharedServerTypes.h
@@ -9,7 +9,7 @@
 #include "JuceHeader.h"
 
 #include "JammerNetzPackage.h"
-#include "PacketStreamQueue.h"
+#include "ClientState.h"
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -42,7 +42,7 @@ public:
 #pragma warning( push )
 #pragma warning( disable : 4996 ) // Disable deprecated warning for now, as it is inside TBB
 #endif
-typedef tbb::concurrent_unordered_map<std::string, std::unique_ptr<PacketStreamQueue>> TPacketStreamBundle;
+typedef tbb::concurrent_unordered_map<std::string, std::shared_ptr<ClientState>> TPacketStreamBundle;
 typedef tbb::concurrent_bounded_queue < OutgoingPackage > TOutgoingQueue;
 typedef tbb::concurrent_bounded_queue<int> TMessageQueue;
 #if WIN32


### PR DESCRIPTION
## Summary
- replace mutable per-client queue ownership with a stable, concurrently published ClientState
- serialize queue access, connection transitions, activity generations, and steady-clock disconnect deadlines
- recover explicitly during the grace period and create a fresh queue without prefill after a completed disconnect
- reject stale underrun decisions when packet activity raced the mixer
- add deterministic transition tests and concurrent accept/mix/send/statistics stress coverage

## Validation
- cmake --build builds --parallel
- ctest --test-dir builds -C Debug --output-on-failure (4/4 passed)
- ctest --test-dir builds -C Debug -R ClientStateTest --repeat until-fail:25 --output-on-failure (all repetitions passed)

Fixes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio client connection handling, including reconnection and grace-period recovery.
  * Added buffering safeguards to reduce disruptions during temporary underruns.
  * Improved stream quality and client status reporting.

* **Bug Fixes**
  * Prevented stale underrun events from incorrectly disconnecting clients.
  * Improved handling of concurrent audio packets and client state updates.

* **Tests**
  * Added coverage for connection transitions, underruns, reconnections, and concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->