### PR TITLE
Phase 3: clean up the real-time audio path

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -56,6 +56,14 @@ source_group(Source\\Resources FILES ${RESOURCE_FILES})
 
 set(CORE_AUDIO_PROCESSING_FILES
 	Source/AtomicSharedPtr.h
+	Source/BoundedSpscQueue.h
+	Source/RealtimeAudioFrames.h
+	Source/AudioTransmitWorker.cpp
+	Source/AudioTransmitWorker.h
+	Source/AudioReceiveWorker.cpp
+	Source/AudioReceiveWorker.h
+	Source/AudioRecordingWorker.cpp
+	Source/AudioRecordingWorker.h
 	Source/JammerNetzAudioEngine.cpp
 	Source/JammerNetzAudioEngine.h
 	Source/MidiSendThread.cpp Source/MidiSendThread.h

--- a/Client/Source/AudioCallback.cpp
+++ b/Client/Source/AudioCallback.cpp
@@ -11,6 +11,12 @@
 AudioCallback::AudioCallback(JammerNetzAudioEngine& engine, std::function<void(float)> serverBpmChanged)
 	: engine_(engine), serverBpmChanged_(std::move(serverBpmChanged))
 {
+	startTimerHz(20);
+}
+
+AudioCallback::~AudioCallback()
+{
+	stopTimer();
 }
 
 void AudioCallback::audioDeviceIOCallbackWithContext(const float* const* inputChannelData, int numInputChannels,
@@ -18,6 +24,10 @@ void AudioCallback::audioDeviceIOCallbackWithContext(const float* const* inputCh
 {
 	juce::ignoreUnused(context);
 	engine_.process(inputChannelData, numInputChannels, outputChannelData, numOutputChannels, numSamples);
+}
+
+void AudioCallback::timerCallback()
+{
 	if (const auto bpm = engine_.takeServerBpmUpdate()) {
 		serverBpmChanged_(*bpm);
 	}

--- a/Client/Source/AudioCallback.h
+++ b/Client/Source/AudioCallback.h
@@ -13,9 +13,10 @@
 
 // Standalone-only adapter. The reusable engine deliberately has no dependency on
 // an AudioIODevice or the application's ValueTree state.
-class AudioCallback final : public juce::AudioIODeviceCallback {
+class AudioCallback final : public juce::AudioIODeviceCallback, private juce::Timer {
 public:
 	AudioCallback(JammerNetzAudioEngine& engine, std::function<void(float)> serverBpmChanged);
+	~AudioCallback() override;
 
 	void audioDeviceIOCallbackWithContext(const float* const* inputChannelData, int numInputChannels, float* const* outputChannelData,
 		int numOutputChannels, int numSamples, const juce::AudioIODeviceCallbackContext& context) override;
@@ -23,6 +24,8 @@ public:
 	void audioDeviceStopped() override;
 
 private:
+	void timerCallback() override;
+
 	JammerNetzAudioEngine& engine_;
 	std::function<void(float)> serverBpmChanged_;
 };

--- a/Client/Source/AudioReceiveWorker.cpp
+++ b/Client/Source/AudioReceiveWorker.cpp
@@ -1,0 +1,253 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "AudioReceiveWorker.h"
+
+#include <cmath>
+#include <utility>
+
+namespace {
+
+uint8 sysexMsb(uint16 value) { return static_cast<uint8>(value >> 7); }
+uint8 sysexLsb(uint16 value) { return static_cast<uint8>(value & 0x7f); }
+
+MidiMessage createBossClockMessage(double bpm, MidiSignal signal)
+{
+	uint16 length = 0;
+	if (signal == MidiSignal_Start) {
+		length = static_cast<uint16>(8 * 96);
+	} else if (signal != MidiSignal_Stop) {
+		return {};
+	}
+	const auto tempo = static_cast<uint16>(std::round(bpm * 10.0));
+	std::vector<uint8> data { 0x41, 0x10, 0x00, 0x00, 0x5C, 0x12, 0x00, 0x01, 0x00, 0x00,
+		sysexMsb(length), sysexLsb(length), sysexMsb(tempo), sysexLsb(tempo), 0x00, 0x00, 0x00, 0x00 };
+	uint16 checksum = 0;
+	for (size_t index = 6; index < data.size(); ++index) {
+		checksum = static_cast<uint16>(checksum + data[index]);
+	}
+	data.push_back(static_cast<uint8>((0x80 - checksum) & 0x7f));
+	return MidiMessage::createSysExMessage(data.data(), static_cast<int>(data.size()));
+}
+
+std::vector<MidiMessage> createBeatMessages(double bpm, MidiSignal signal)
+{
+	std::vector<MidiMessage> messages;
+	messages.reserve(3);
+	messages.push_back(MidiMessage::midiClock());
+	if (signal == MidiSignal_Start) {
+		messages.push_back(MidiMessage::midiStart());
+		messages.push_back(createBossClockMessage(bpm, signal));
+	} else if (signal == MidiSignal_Stop) {
+		messages.push_back(MidiMessage::midiStop());
+		messages.push_back(createBossClockMessage(bpm, signal));
+	}
+	return messages;
+}
+
+} // namespace
+
+AudioReceiveWorker::AudioReceiveWorker(JammerNetzSession& session)
+	: juce::Thread("JammerNetz receive preparation"), session_(session)
+{
+}
+
+AudioReceiveWorker::~AudioReceiveWorker() { shutdown(); }
+
+void AudioReceiveWorker::start()
+{
+	if (!isThreadRunning()) {
+		startThread(juce::Thread::Priority::high);
+	}
+}
+
+void AudioReceiveWorker::shutdown()
+{
+	signalThreadShouldExit();
+	stopThread(2000);
+	midiSender_.store(nullptr, std::memory_order_release);
+}
+
+void AudioReceiveWorker::enqueue(std::shared_ptr<JammerNetzAudioData> packet)
+{
+	if (packet && !inboundQueue_.tryWrite([&packet](std::shared_ptr<JammerNetzAudioData>& slot) { slot = std::move(packet); })) {
+		inboundOverruns_.fetch_add(1, std::memory_order_relaxed);
+	}
+}
+
+bool AudioReceiveWorker::tryPop(RemoteAudioFrame& frame)
+{
+	return outputQueue_.tryRead([&frame](RemoteAudioFrame& queued) { frame = queued; });
+}
+
+int AudioReceiveWorker::readyFrames() const noexcept { return outputQueue_.size(); }
+
+void AudioReceiveWorker::setPlayoutRange(uint64_t minimumFrames, uint64_t maximumFrames) noexcept
+{
+	minimumFrames_.store(minimumFrames, std::memory_order_relaxed);
+	maximumFrames_.store(std::max(minimumFrames, maximumFrames), std::memory_order_relaxed);
+}
+
+void AudioReceiveWorker::setMidiSender(std::shared_ptr<MidiSendThread> sender)
+{
+	midiSender_.store(std::move(sender), std::memory_order_release);
+}
+
+void AudioReceiveWorker::requestRebuffer() noexcept { rebufferRequested_.store(true, std::memory_order_release); }
+
+uint64_t AudioReceiveWorker::requestReset() noexcept
+{
+	return requestedGeneration_.fetch_add(1, std::memory_order_acq_rel) + 1;
+}
+
+uint64_t AudioReceiveWorker::currentGeneration() const noexcept { return requestedGeneration_.load(std::memory_order_acquire); }
+
+std::optional<float> AudioReceiveWorker::takeServerBpmUpdate() noexcept
+{
+	if (serverBpmPending_.exchange(false, std::memory_order_acq_rel)) {
+		return latestServerBpm_.load(std::memory_order_relaxed);
+	}
+	return {};
+}
+
+uint64_t AudioReceiveWorker::discardedFrames() const noexcept
+{
+	return discarded_.load(std::memory_order_relaxed) + inboundOverruns_.load(std::memory_order_relaxed);
+}
+uint64_t AudioReceiveWorker::outputQueueOverruns() const noexcept
+{
+	return inboundOverruns_.load(std::memory_order_relaxed) + outputOverruns_.load(std::memory_order_relaxed);
+}
+std::string AudioReceiveWorker::qualityStatement() const { return packetQueue_.qualityStatement(); }
+FFAU::LevelMeterSource* AudioReceiveWorker::meterSource() noexcept { return &sessionMeterSource_; }
+
+void AudioReceiveWorker::run()
+{
+	while (!threadShouldExit()) {
+		applyResetIfRequested();
+		drainInbound();
+		if (rebufferRequested_.exchange(false, std::memory_order_acq_rel)) {
+			streamStarted_.store(false, std::memory_order_release);
+		}
+
+		const auto minimum = minimumFrames_.load(std::memory_order_relaxed);
+		if (!streamStarted_.load(std::memory_order_acquire) && packetQueue_.size() >= minimum) {
+			streamStarted_.store(true, std::memory_order_release);
+		}
+
+		const auto maximum = maximumFrames_.load(std::memory_order_relaxed);
+		std::shared_ptr<JammerNetzAudioData> discardedPacket;
+		bool fillIn = false;
+		while (packetQueue_.size() > maximum && packetQueue_.try_pop(discardedPacket, fillIn)) {
+			discarded_.fetch_add(1, std::memory_order_relaxed);
+		}
+
+		const bool prepared = streamStarted_.load(std::memory_order_acquire) && prepareOneFrame();
+		if (!prepared) {
+			juce::Thread::sleep(1);
+		}
+	}
+}
+
+void AudioReceiveWorker::applyResetIfRequested()
+{
+	const auto requested = requestedGeneration_.load(std::memory_order_acquire);
+	if (requested == activeGeneration_.load(std::memory_order_relaxed)) {
+		return;
+	}
+	std::shared_ptr<JammerNetzAudioData> packet;
+	while (inboundQueue_.tryRead([&packet](std::shared_ptr<JammerNetzAudioData>& queued) { packet = std::move(queued); })) {}
+	packetQueue_.reset();
+	streamStarted_.store(false, std::memory_order_release);
+	activeGeneration_.store(requested, std::memory_order_release);
+}
+
+void AudioReceiveWorker::drainInbound()
+{
+	std::shared_ptr<JammerNetzAudioData> packet;
+	while (inboundQueue_.tryRead([&packet](std::shared_ptr<JammerNetzAudioData>& queued) { packet = std::move(queued); })) {
+		packetQueue_.push(std::move(packet));
+	}
+}
+
+bool AudioReceiveWorker::prepareOneFrame()
+{
+	if (outputQueue_.freeSpace() == 0) {
+		return false;
+	}
+	std::shared_ptr<JammerNetzAudioData> packet;
+	bool fillIn = false;
+	if (!packetQueue_.try_pop(packet, fillIn) || !packet || !packet->audioBuffer()) {
+		return false;
+	}
+
+	const auto audio = packet->audioBuffer();
+	const auto generation = activeGeneration_.load(std::memory_order_acquire);
+	const bool written = outputQueue_.tryWrite([&](RemoteAudioFrame& frame) {
+		frame.generation = generation;
+		frame.sourceTimestamp = packet->timestamp();
+		for (int channel = 0; channel < 2; ++channel) {
+			auto& destination = frame.samples[static_cast<size_t>(channel)];
+			if (channel < audio->getNumChannels()) {
+				const auto samplesToCopy = std::min(SAMPLE_BUFFER_SIZE, audio->getNumSamples());
+				juce::FloatVectorOperations::copy(destination.data(), audio->getReadPointer(channel), samplesToCopy);
+				juce::FloatVectorOperations::clear(destination.data() + samplesToCopy, SAMPLE_BUFFER_SIZE - samplesToCopy);
+			} else {
+				destination.fill(0.0f);
+			}
+		}
+	});
+	if (!written) {
+		outputOverruns_.fetch_add(1, std::memory_order_relaxed);
+		return false;
+	}
+
+	latestServerBpm_.store(packet->bpm(), std::memory_order_relaxed);
+	serverBpmPending_.store(true, std::memory_order_release);
+	if (packet->midiSignal() != MidiSignal_None) {
+		pendingMidiSignal_ = packet->midiSignal();
+	}
+	scheduleMidi(*packet);
+	updateSessionMeter();
+	return true;
+}
+
+void AudioReceiveWorker::scheduleMidi(const JammerNetzAudioData& packet)
+{
+	const auto sender = midiSender_.load(std::memory_order_acquire);
+	const double bpm = packet.bpm();
+	if (!sender || bpm <= 0.0) {
+		return;
+	}
+	constexpr double pulsesPerQuarterNote = 24.0;
+	const double samplesPerPulse = static_cast<double>(SAMPLE_RATE) / (bpm * pulsesPerQuarterNote / 60.0);
+	if (samplesPerPulse <= SAMPLE_BUFFER_SIZE) {
+		return;
+	}
+	const double serverSamples = static_cast<double>(packet.serverTime());
+	const double endPulse = std::floor((serverSamples + SAMPLE_BUFFER_SIZE) / samplesPerPulse);
+	const double startPulse = std::floor(serverSamples / samplesPerPulse);
+	if (endPulse - startPulse < 1.0e-6) {
+		return;
+	}
+	const double offsetSamples = endPulse * samplesPerPulse - serverSamples;
+	sender->enqueue(std::chrono::nanoseconds(static_cast<int64_t>(1.0e9 * offsetSamples / SAMPLE_RATE)),
+		createBeatMessages(bpm, std::exchange(pendingMidiSignal_, MidiSignal_None)));
+}
+
+void AudioReceiveWorker::updateSessionMeter()
+{
+	const auto setup = session_.getCurrentSessionSetup();
+	std::vector<float> magnitudes;
+	std::vector<float> rms;
+	magnitudes.reserve(setup.channels.size());
+	rms.reserve(setup.channels.size());
+	for (const auto& channel : setup.channels) {
+		magnitudes.push_back(channel.mag);
+		rms.push_back(channel.rms);
+	}
+	sessionMeterSource_.setBlockMeasurement(setup.channels.size(), magnitudes, rms);
+}

--- a/Client/Source/AudioReceiveWorker.h
+++ b/Client/Source/AudioReceiveWorker.h
@@ -1,0 +1,70 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "AtomicSharedPtr.h"
+#include "BoundedSpscQueue.h"
+#include "IncludeFFMeters.h"
+#include "JammerNetzSession.h"
+#include "MidiSendThread.h"
+#include "PacketStreamQueue.h"
+#include "RealtimeAudioFrames.h"
+
+class AudioReceiveWorker final : private juce::Thread {
+public:
+	explicit AudioReceiveWorker(JammerNetzSession& session);
+	~AudioReceiveWorker() override;
+
+	void start();
+	void shutdown();
+	void enqueue(std::shared_ptr<JammerNetzAudioData> packet);
+	bool tryPop(RemoteAudioFrame& frame);
+	int readyFrames() const noexcept;
+
+	void setPlayoutRange(uint64_t minimumFrames, uint64_t maximumFrames) noexcept;
+	void setMidiSender(std::shared_ptr<MidiSendThread> sender);
+	void requestRebuffer() noexcept;
+	uint64_t requestReset() noexcept;
+	uint64_t currentGeneration() const noexcept;
+	std::optional<float> takeServerBpmUpdate() noexcept;
+
+	uint64_t discardedFrames() const noexcept;
+	uint64_t outputQueueOverruns() const noexcept;
+	std::string qualityStatement() const;
+	FFAU::LevelMeterSource* meterSource() noexcept;
+
+private:
+	void run() override;
+	void applyResetIfRequested();
+	void drainInbound();
+	bool prepareOneFrame();
+	void scheduleMidi(const JammerNetzAudioData& packet);
+	void updateSessionMeter();
+
+	// Network bursts are dropped at 512 packets. Prepared PCM waits in a
+	// separate 256-frame queue; the worker pauses instead of blocking audio.
+	static constexpr int inputCapacity = 512;
+	static constexpr int outputCapacity = 256;
+	JammerNetzSession& session_;
+	BoundedSpscQueue<std::shared_ptr<JammerNetzAudioData>> inboundQueue_ { inputCapacity };
+	PacketStreamQueue packetQueue_ { "server" };
+	BoundedSpscQueue<RemoteAudioFrame> outputQueue_ { outputCapacity };
+	AtomicSharedPtr<MidiSendThread> midiSender_;
+	FFAU::LevelMeterSource sessionMeterSource_;
+	std::atomic<uint64_t> minimumFrames_ { CLIENT_PLAYOUT_JITTER_BUFFER };
+	std::atomic<uint64_t> maximumFrames_ { CLIENT_PLAYOUT_MAX_BUFFER };
+	std::atomic<bool> rebufferRequested_ { false };
+	std::atomic<uint64_t> requestedGeneration_ { 0 };
+	std::atomic<uint64_t> activeGeneration_ { 0 };
+	std::atomic<bool> streamStarted_ { false };
+	std::atomic<float> latestServerBpm_ { 0.0f };
+	std::atomic<bool> serverBpmPending_ { false };
+	std::atomic<uint64_t> discarded_ { 0 };
+	std::atomic<uint64_t> inboundOverruns_ { 0 };
+	std::atomic<uint64_t> outputOverruns_ { 0 };
+	MidiSignal pendingMidiSignal_ { MidiSignal_None };
+};

--- a/Client/Source/AudioRecordingWorker.cpp
+++ b/Client/Source/AudioRecordingWorker.cpp
@@ -1,0 +1,85 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "AudioRecordingWorker.h"
+
+AudioRecordingWorker::AudioRecordingWorker(std::shared_ptr<Recorder> localRecorder, std::shared_ptr<Recorder> masterRecorder)
+	: juce::Thread("JammerNetz recording handoff")
+	, localRecorder_(std::move(localRecorder))
+	, masterRecorder_(std::move(masterRecorder))
+{
+}
+
+AudioRecordingWorker::~AudioRecordingWorker() { shutdown(); }
+
+void AudioRecordingWorker::start()
+{
+	if (!isThreadRunning()) {
+		startThread();
+	}
+}
+
+void AudioRecordingWorker::shutdown()
+{
+	signalThreadShouldExit();
+	stopThread(2000);
+}
+
+bool AudioRecordingWorker::enqueue(RecordingTarget target, const float* const* channels, int numChannels, int numSamples) noexcept
+{
+	const auto& recorder = target == RecordingTarget::local ? localRecorder_ : masterRecorder_;
+	if (!recorder || !recorder->isRecording()) {
+		return true;
+	}
+	if (!channels || numChannels <= 0 || numChannels > JAMMERNETZ_MAX_AUDIO_CHANNELS
+		|| numSamples <= 0 || numSamples > JAMMERNETZ_MAX_CALLBACK_SAMPLES) {
+		dropped_.fetch_add(1, std::memory_order_relaxed);
+		return false;
+	}
+	const bool queued = queue_.tryWrite([&](RecordingAudioFrame& frame) {
+		frame.target = target;
+		frame.channels = numChannels;
+		frame.samplesPerChannel = numSamples;
+		for (int channel = 0; channel < numChannels; ++channel) {
+			if (channels[channel]) {
+				juce::FloatVectorOperations::copy(frame.samples[static_cast<size_t>(channel)].data(), channels[channel], numSamples);
+			} else {
+				juce::FloatVectorOperations::clear(frame.samples[static_cast<size_t>(channel)].data(), numSamples);
+			}
+		}
+	});
+	if (!queued) {
+		dropped_.fetch_add(1, std::memory_order_relaxed);
+	}
+	return queued;
+}
+
+uint64_t AudioRecordingWorker::writtenFrames() const noexcept { return written_.load(std::memory_order_relaxed); }
+uint64_t AudioRecordingWorker::droppedFrames() const noexcept { return dropped_.load(std::memory_order_relaxed); }
+
+void AudioRecordingWorker::run()
+{
+	while (!threadShouldExit()) {
+		const bool hadFrame = queue_.tryRead([this](RecordingAudioFrame& frame) { writeFrame(frame); });
+		if (!hadFrame) {
+			juce::Thread::sleep(2);
+		}
+	}
+}
+
+void AudioRecordingWorker::writeFrame(RecordingAudioFrame& frame)
+{
+	const auto& recorder = frame.target == RecordingTarget::local ? localRecorder_ : masterRecorder_;
+	if (!recorder || !recorder->isRecording()) {
+		return;
+	}
+	std::array<const float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> pointers {};
+	for (int channel = 0; channel < frame.channels; ++channel) {
+		pointers[static_cast<size_t>(channel)] = frame.samples[static_cast<size_t>(channel)].data();
+	}
+	recorder->saveBlock(pointers.data(), frame.samplesPerChannel);
+	written_.fetch_add(1, std::memory_order_relaxed);
+}

--- a/Client/Source/AudioRecordingWorker.cpp
+++ b/Client/Source/AudioRecordingWorker.cpp
@@ -31,7 +31,8 @@ void AudioRecordingWorker::shutdown()
 bool AudioRecordingWorker::enqueue(RecordingTarget target, const float* const* channels, int numChannels, int numSamples) noexcept
 {
 	const auto& recorder = target == RecordingTarget::local ? localRecorder_ : masterRecorder_;
-	if (!recorder || !recorder->isRecording()) {
+	const auto recordingGeneration = recorder ? recorder->recordingGeneration() : 0;
+	if (recordingGeneration == 0) {
 		return true;
 	}
 	if (!channels || numChannels <= 0 || numChannels > JAMMERNETZ_MAX_AUDIO_CHANNELS
@@ -41,6 +42,7 @@ bool AudioRecordingWorker::enqueue(RecordingTarget target, const float* const* c
 	}
 	const bool queued = queue_.tryWrite([&](RecordingAudioFrame& frame) {
 		frame.target = target;
+		frame.recordingGeneration = recordingGeneration;
 		frame.channels = numChannels;
 		frame.samplesPerChannel = numSamples;
 		for (int channel = 0; channel < numChannels; ++channel) {
@@ -62,7 +64,7 @@ uint64_t AudioRecordingWorker::droppedFrames() const noexcept { return dropped_.
 
 void AudioRecordingWorker::run()
 {
-	while (!threadShouldExit()) {
+	while (!threadShouldExit() || queue_.size() > 0) {
 		const bool hadFrame = queue_.tryRead([this](RecordingAudioFrame& frame) { writeFrame(frame); });
 		if (!hadFrame) {
 			juce::Thread::sleep(2);
@@ -73,7 +75,7 @@ void AudioRecordingWorker::run()
 void AudioRecordingWorker::writeFrame(RecordingAudioFrame& frame)
 {
 	const auto& recorder = frame.target == RecordingTarget::local ? localRecorder_ : masterRecorder_;
-	if (!recorder || !recorder->isRecording()) {
+	if (!recorder || frame.recordingGeneration != recorder->recordingGeneration()) {
 		return;
 	}
 	std::array<const float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> pointers {};

--- a/Client/Source/AudioRecordingWorker.h
+++ b/Client/Source/AudioRecordingWorker.h
@@ -1,0 +1,36 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "BoundedSpscQueue.h"
+#include "RealtimeAudioFrames.h"
+#include "Recorder.h"
+
+class AudioRecordingWorker final : private juce::Thread {
+public:
+	AudioRecordingWorker(std::shared_ptr<Recorder> localRecorder, std::shared_ptr<Recorder> masterRecorder);
+	~AudioRecordingWorker() override;
+
+	void start();
+	void shutdown();
+	bool enqueue(RecordingTarget target, const float* const* channels, int numChannels, int numSamples) noexcept;
+
+	uint64_t writtenFrames() const noexcept;
+	uint64_t droppedFrames() const noexcept;
+
+private:
+	void run() override;
+	void writeFrame(RecordingAudioFrame& frame);
+
+	// Recording is best-effort: the ninth pending callback block is dropped.
+	static constexpr int queueCapacity = 8;
+	BoundedSpscQueue<RecordingAudioFrame> queue_ { queueCapacity };
+	std::shared_ptr<Recorder> localRecorder_;
+	std::shared_ptr<Recorder> masterRecorder_;
+	std::atomic<uint64_t> written_ { 0 };
+	std::atomic<uint64_t> dropped_ { 0 };
+};

--- a/Client/Source/AudioService.cpp
+++ b/Client/Source/AudioService.cpp
@@ -51,8 +51,8 @@ void AudioService::shutdown()
 		return;
 	}
 	stopAudioIfRunning();
-	session_.shutdown();
 	engine_.shutdown();
+	session_.shutdown();
 }
 
 bool AudioService::isConnected()

--- a/Client/Source/AudioTransmitWorker.cpp
+++ b/Client/Source/AudioTransmitWorker.cpp
@@ -1,0 +1,121 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "AudioTransmitWorker.h"
+
+AudioTransmitWorker::AudioTransmitWorker(JammerNetzSession& session)
+	: juce::Thread("JammerNetz transmit"), session_(session)
+{
+	channelSetup_.store(std::make_shared<const JammerNetzChannelSetup>(false), std::memory_order_release);
+}
+
+AudioTransmitWorker::~AudioTransmitWorker()
+{
+	shutdown();
+}
+
+void AudioTransmitWorker::start()
+{
+	if (!isThreadRunning()) {
+		startThread(juce::Thread::Priority::high);
+	}
+}
+
+void AudioTransmitWorker::shutdown()
+{
+	signalThreadShouldExit();
+	stopThread(2000);
+}
+
+void AudioTransmitWorker::setChannelSetup(const JammerNetzChannelSetup& setup)
+{
+	channelSetup_.store(std::make_shared<const JammerNetzChannelSetup>(setup), std::memory_order_release);
+}
+
+bool AudioTransmitWorker::hasCapacity() const noexcept
+{
+	return queue_.freeSpace() > 0;
+}
+
+bool AudioTransmitWorker::enqueueFrom(RingBuffer& source, int channels, std::optional<float> bpm, std::optional<MidiSignal> midiSignal)
+{
+	if (channels <= 0 || channels > JAMMERNETZ_MAX_AUDIO_CHANNELS) {
+		recordDroppedFrame();
+		return false;
+	}
+
+	const bool written = queue_.tryWrite([&](TransmitAudioFrame& frame) {
+		frame.channels = channels;
+		frame.bpm = bpm;
+		frame.midiSignal = midiSignal;
+		std::array<float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> pointers {};
+		for (int channel = 0; channel < channels; ++channel) {
+			pointers[static_cast<size_t>(channel)] = frame.samples[static_cast<size_t>(channel)].data();
+		}
+		source.read(pointers.data(), channels, SAMPLE_BUFFER_SIZE);
+	});
+
+	if (written) {
+		enqueued_.fetch_add(1, std::memory_order_relaxed);
+	} else {
+		recordDroppedFrame();
+	}
+	return written;
+}
+
+void AudioTransmitWorker::recordDroppedFrame() noexcept
+{
+	dropped_.fetch_add(1, std::memory_order_relaxed);
+}
+
+uint64_t AudioTransmitWorker::enqueuedFrames() const noexcept { return enqueued_.load(std::memory_order_relaxed); }
+uint64_t AudioTransmitWorker::sentFrames() const noexcept { return sent_.load(std::memory_order_relaxed); }
+uint64_t AudioTransmitWorker::droppedFrames() const noexcept { return dropped_.load(std::memory_order_relaxed); }
+float AudioTransmitWorker::channelPitch(size_t channel) const { return tuner_.getPitch(channel); }
+FFAU::LevelMeterSource* AudioTransmitWorker::meterSource() noexcept { return &meterSource_; }
+
+void AudioTransmitWorker::run()
+{
+	while (!threadShouldExit()) {
+		const bool hadFrame = queue_.tryRead([this](TransmitAudioFrame& frame) { processFrame(frame); });
+		if (!hadFrame) {
+			juce::Thread::sleep(1);
+		}
+	}
+}
+
+void AudioTransmitWorker::processFrame(TransmitAudioFrame& frame)
+{
+	std::array<float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> pointers {};
+	for (int channel = 0; channel < frame.channels; ++channel) {
+		pointers[static_cast<size_t>(channel)] = frame.samples[static_cast<size_t>(channel)].data();
+	}
+	auto audio = std::make_shared<juce::AudioBuffer<float>>(pointers.data(), frame.channels, SAMPLE_BUFFER_SIZE);
+	tuner_.detectPitch(audio);
+	meterSource_.measureBlock(*audio);
+
+	const auto setup = channelSetup_.load(std::memory_order_acquire);
+	if (!setup || setup->channels.size() != static_cast<size_t>(frame.channels)) {
+		recordDroppedFrame();
+		return;
+	}
+	JammerNetzChannelSetup outgoing = *setup;
+	for (int channel = 0; channel < frame.channels; ++channel) {
+		auto& details = outgoing.channels[static_cast<size_t>(channel)];
+		details.mag = meterSource_.getMaxLevel(channel);
+		details.rms = meterSource_.getRMSLevel(channel);
+		details.pitch = tuner_.getPitch(static_cast<size_t>(channel));
+	}
+
+	if (auto* sender = session_.sender()) {
+		ControlData controls;
+		controls.bpm = frame.bpm;
+		controls.midiSignal = frame.midiSignal;
+		if (sender->sendData(outgoing, audio, controls)) {
+			sent_.fetch_add(1, std::memory_order_relaxed);
+		}
+	}
+}

--- a/Client/Source/AudioTransmitWorker.h
+++ b/Client/Source/AudioTransmitWorker.h
@@ -1,0 +1,50 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "AtomicSharedPtr.h"
+#include "BoundedSpscQueue.h"
+#include "IncludeFFMeters.h"
+#include "JammerNetzSession.h"
+#include "RealtimeAudioFrames.h"
+#include "RingBuffer.h"
+#include "Tuner.h"
+
+class AudioTransmitWorker final : private juce::Thread {
+public:
+	explicit AudioTransmitWorker(JammerNetzSession& session);
+	~AudioTransmitWorker() override;
+
+	void start();
+	void shutdown();
+	void setChannelSetup(const JammerNetzChannelSetup& setup);
+
+	bool hasCapacity() const noexcept;
+	bool enqueueFrom(RingBuffer& source, int channels, std::optional<float> bpm, std::optional<MidiSignal> midiSignal);
+	void recordDroppedFrame() noexcept;
+
+	uint64_t enqueuedFrames() const noexcept;
+	uint64_t sentFrames() const noexcept;
+	uint64_t droppedFrames() const noexcept;
+	float channelPitch(size_t channel) const;
+	FFAU::LevelMeterSource* meterSource() noexcept;
+
+private:
+	void run() override;
+	void processFrame(TransmitAudioFrame& frame);
+
+	// About 170 ms at 48 kHz. New frames are dropped when the worker stalls.
+	static constexpr int queueCapacity = 64;
+	JammerNetzSession& session_;
+	BoundedSpscQueue<TransmitAudioFrame> queue_ { queueCapacity };
+	AtomicSharedPtr<const JammerNetzChannelSetup> channelSetup_;
+	Tuner tuner_;
+	FFAU::LevelMeterSource meterSource_;
+	std::atomic<uint64_t> enqueued_ { 0 };
+	std::atomic<uint64_t> sent_ { 0 };
+	std::atomic<uint64_t> dropped_ { 0 };
+};

--- a/Client/Source/BoundedSpscQueue.h
+++ b/Client/Source/BoundedSpscQueue.h
@@ -1,0 +1,54 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "JuceHeader.h"
+
+#include <vector>
+
+// Fixed-capacity single-producer/single-consumer storage. Slots are allocated
+// during construction and are filled in place, so enqueue/dequeue never allocates.
+template <typename Item>
+class BoundedSpscQueue {
+public:
+	explicit BoundedSpscQueue(int capacity) : fifo_(capacity), slots_(static_cast<size_t>(capacity)) {}
+
+	template <typename Writer>
+	bool tryWrite(Writer&& writer)
+	{
+		int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+		fifo_.prepareToWrite(1, start1, size1, start2, size2);
+		juce::ignoreUnused(start2, size2);
+		if (size1 == 0) {
+			return false;
+		}
+		writer(slots_[static_cast<size_t>(start1)]);
+		fifo_.finishedWrite(1);
+		return true;
+	}
+
+	template <typename Reader>
+	bool tryRead(Reader&& reader)
+	{
+		int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+		fifo_.prepareToRead(1, start1, size1, start2, size2);
+		juce::ignoreUnused(start2, size2);
+		if (size1 == 0) {
+			return false;
+		}
+		reader(slots_[static_cast<size_t>(start1)]);
+		fifo_.finishedRead(1);
+		return true;
+	}
+
+	int size() const noexcept { return fifo_.getNumReady(); }
+	int freeSpace() const noexcept { return fifo_.getFreeSpace(); }
+
+private:
+	juce::AbstractFifo fifo_;
+	std::vector<Item> slots_;
+};

--- a/Client/Source/JammerNetzAudioEngine.cpp
+++ b/Client/Source/JammerNetzAudioEngine.cpp
@@ -6,42 +6,36 @@
 
 #include "JammerNetzAudioEngine.h"
 
-#include "ServerInfo.h"
-
 #include "BuffersConfig.h"
-#include "Logger.h"
 
 #include <cmath>
 
-JammerNetzAudioEngine::JammerNetzAudioEngine(JammerNetzSession& session, const juce::File& recordingDirectory) :
-    session_(session)
+JammerNetzAudioEngine::JammerNetzAudioEngine(JammerNetzSession& session, const juce::File& recordingDirectory)
+	: session_(session)
 	, recordingDirectory_(recordingDirectory)
-    , playBuffer_("server")
-    , masterVolume_(1.0)
-    , monitorBalance_(0.0)
-    , clientBpm_(0.0f)
-    , serverBpm_(0.0)
-    , ignoreNextServerBpmChange_(false)
-    , pendingServerBpm_(0.0f)
-	, serverBpmUpdate_(0.0f)
+	, remoteScratch_(2, JAMMERNETZ_MAX_CALLBACK_SAMPLES)
+	, masterVolume_(1.0)
+	, monitorBalance_(0.0)
+	, clientBpm_(0.0f)
+	, serverBpm_(0.0)
+	, ignoreNextServerBpmChange_(false)
+	, pendingServerBpm_(0.0f)
 	, bpmSliderLastMovedTicks_(0)
-    , midiSignalToSend_(MidiSignal_None)
-    , midiSignalToGenerate_(MidiSignal_None)
+	, midiSignalToSend_(MidiSignal_None)
 {
-	inputState_.store(std::make_shared<const InputState>(InputState { JammerNetzChannelSetup(false), nullptr }), std::memory_order_release);
-	isPlaying_ = false;
-	resetQualityInfo_ = false;
+	configuredInputState_ = std::make_shared<const InputState>(InputState { JammerNetzChannelSetup(false), nullptr });
+	inputState_.store(configuredInputState_.get(), std::memory_order_release);
 	minPlayoutBufferLength_ = CLIENT_PLAYOUT_JITTER_BUFFER;
 	maxPlayoutBufferLength_ = CLIENT_PLAYOUT_MAX_BUFFER;
 	playoutBuffer_ = std::make_unique<RingBuffer>(2, PLAYOUT_RINGBUFFER_SIZE);
+	transmitWorker_ = std::make_unique<AudioTransmitWorker>(session_);
+	receiveWorker_ = std::make_unique<AudioReceiveWorker>(session_);
+	outMeterSource_.resize(2, 1);
 
 	//midiRecorder_ = std::make_unique<MidiRecorder>(deviceManager);
 
 	// We might want to share a score sheet or similar
 	//midiPlayalong_ = std::make_unique<MidiPlayAlong>("D:\\Development\\JammerNetz-OS\\Led Zeppelin - Stairway to heaven (1).kar");
-
-	// We want to be able to tune our instruments
-	tuner_ = std::make_unique<Tuner>();
 
 }
 
@@ -58,10 +52,24 @@ void JammerNetzAudioEngine::start()
 	uploadRecorder_ = std::make_shared<Recorder>(recordingDirectory_, "LocalRecording", RecordingType::WAV);
 	masterRecorder_ = std::make_shared<Recorder>(recordingDirectory_, "MasterRecording", RecordingType::FLAC);
 	masterRecorder_->setChannelInfo(SAMPLE_RATE, JammerNetzChannelSetup(false, { JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left), JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right) }));
+	recordingWorker_ = std::make_unique<AudioRecordingWorker>(uploadRecorder_, masterRecorder_);
+	recordingWorker_->start();
+	transmitWorker_->start();
+	receiveWorker_->start();
 }
 
 void JammerNetzAudioEngine::shutdown()
 {
+	if (recordingWorker_) {
+		recordingWorker_->shutdown();
+		recordingWorker_.reset();
+	}
+	if (transmitWorker_) {
+		transmitWorker_->shutdown();
+	}
+	if (receiveWorker_) {
+		receiveWorker_->shutdown();
+	}
 	midiSendThread_.store(nullptr, std::memory_order_release);
 	masterRecorder_.reset();
 	uploadRecorder_.reset();
@@ -69,13 +77,18 @@ void JammerNetzAudioEngine::shutdown()
 
 void JammerNetzAudioEngine::enqueueRemoteAudio(std::shared_ptr<JammerNetzAudioData> buffer)
 {
-	playBuffer_.push(std::move(buffer));
+	if (receiveWorker_) {
+		receiveWorker_->enqueue(std::move(buffer));
+	}
 }
 
 void JammerNetzAudioEngine::setPlayoutBufferRange(uint64 minimumLength, uint64 maximumLength)
 {
 	minPlayoutBufferLength_.store(minimumLength, std::memory_order_relaxed);
 	maxPlayoutBufferLength_.store(std::max(minimumLength, maximumLength), std::memory_order_relaxed);
+	if (receiveWorker_) {
+		receiveWorker_->setPlayoutRange(minimumLength, maximumLength);
+	}
 }
 
 void JammerNetzAudioEngine::setMasterVolume(double volume)
@@ -108,13 +121,34 @@ void JammerNetzAudioEngine::setClientBpm(float bpm)
 
 std::optional<float> JammerNetzAudioEngine::takeServerBpmUpdate()
 {
-	return serverBpmUpdate_.readOnce();
+	if (!receiveWorker_) {
+		return {};
+	}
+	const auto bpm = receiveWorker_->takeServerBpmUpdate();
+	if (!bpm) {
+		return {};
+	}
+	const auto now = std::chrono::steady_clock::now();
+	const auto lastMovedTicks = bpmSliderLastMovedTicks_.load(std::memory_order_acquire);
+	const auto lastMoved = std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(lastMovedTicks));
+	if (lastMovedTicks != 0 && now - lastMoved <= std::chrono::seconds(1)) {
+		return {};
+	}
+	serverBpm_.store(*bpm, std::memory_order_relaxed);
+	pendingServerBpm_.store(*bpm, std::memory_order_release);
+	ignoreNextServerBpmChange_.store(true, std::memory_order_release);
+	bpmSliderLastMovedTicks_.store(now.time_since_epoch().count(), std::memory_order_release);
+	return bpm;
 }
 
 void JammerNetzAudioEngine::restartClock(std::vector<MidiDeviceInfo> outputs)
 {
 	// Where to send the Midi Clock signals
-	midiSendThread_.store(std::make_shared<MidiSendThread>(outputs), std::memory_order_release);
+	auto sender = std::make_shared<MidiSendThread>(outputs);
+	midiSendThread_.store(sender, std::memory_order_release);
+	if (receiveWorker_) {
+		receiveWorker_->setMidiSender(std::move(sender));
+	}
 }
 
 void JammerNetzAudioEngine::setMidiSignalToSend(MidiSignal signal)
@@ -124,14 +158,11 @@ void JammerNetzAudioEngine::setMidiSignalToSend(MidiSignal signal)
 
 void JammerNetzAudioEngine::newServer()
 {
-	// Reset counters etc
-	PlayoutQualityInfo pqi;
-	while (playoutQualityInfo_.try_pop(pqi));
 	resetQualityInfo_.store(true, std::memory_order_release);
-	isPlaying_ = false;
-	std::shared_ptr<JammerNetzAudioData> elem;
-	bool isFillIn;
-	while (playBuffer_.try_pop(elem, isFillIn));
+	resetPlayoutRequested_.store(true, std::memory_order_release);
+	if (receiveWorker_) {
+		expectedRemoteGeneration_.store(receiveWorker_->requestReset(), std::memory_order_release);
+	}
 }
 
 void JammerNetzAudioEngine::measureSamplesPerTime(PlayoutQualityInfo &qualityInfo, int numSamples) const {
@@ -158,15 +189,15 @@ static std::pair<double, double> calcMonitorGain(double t) {
 	return { left, right };
 }
 
-void JammerNetzAudioEngine::calcLocalMonitoring(const AudioBuffer<float>& inputBuffer, AudioBuffer<float>& outputBuffer, const JammerNetzChannelSetup& channelSetup) {
-
-	outputBuffer.clear();
-	if (monitorIsLocal_ && inputBuffer.getNumChannels() > 0) {
+void JammerNetzAudioEngine::calcLocalMonitoring(const float* const* inputChannels, int numInputChannels, AudioBuffer<float>& outputBuffer,
+	const JammerNetzChannelSetup& channelSetup) {
+	if (monitorIsLocal_ && inputChannels && numInputChannels > 0) {
 		auto [monitorVolume, _] = calcMonitorGain(monitorBalance_.load(std::memory_order_relaxed));
-		// Apply gain to our channels and do a stereo mixdown
-		jassert(inputBuffer.getNumSamples() == outputBuffer.getNumSamples());
-		const auto channelsToMix = std::min(static_cast<size_t>(inputBuffer.getNumChannels()), channelSetup.channels.size());
+		const auto channelsToMix = std::min(static_cast<size_t>(numInputChannels), channelSetup.channels.size());
 		for (size_t channel = 0; channel < channelsToMix; channel++) {
+			if (!inputChannels[channel]) {
+				continue;
+			}
 			const JammerNetzSingleChannelSetup& setup = channelSetup.channels[channel];
 			float input_volume = (float) (setup.volume * monitorVolume * masterVolume_);
 			switch (setup.target) {
@@ -176,13 +207,13 @@ void JammerNetzAudioEngine::calcLocalMonitoring(const AudioBuffer<float>& inputB
 			case Left:
 				// This is a left channel, going into the left.
 				if (outputBuffer.getNumChannels() > 0) {
-					outputBuffer.addFrom(0, 0, inputBuffer, (int) channel, 0, inputBuffer.getNumSamples(), input_volume);
+					outputBuffer.addFrom(0, 0, inputChannels[channel], outputBuffer.getNumSamples(), input_volume);
 				}
 				break;
 			case Right:
 				// And the same for the right channel
 				if (outputBuffer.getNumChannels() > 1) {
-					outputBuffer.addFrom(1, 0, inputBuffer, (int) channel, 0, inputBuffer.getNumSamples(), input_volume);
+					outputBuffer.addFrom(1, 0, inputChannels[channel], outputBuffer.getNumSamples(), input_volume);
 				}
 				break;
 			case SendLeft:
@@ -192,10 +223,10 @@ void JammerNetzAudioEngine::calcLocalMonitoring(const AudioBuffer<float>& inputB
 				break;
 			case Mono:
 				if (outputBuffer.getNumChannels() > 0) {
-					outputBuffer.addFrom(0, 0, inputBuffer, (int) channel, 0, inputBuffer.getNumSamples(), input_volume);
+					outputBuffer.addFrom(0, 0, inputChannels[channel], outputBuffer.getNumSamples(), input_volume);
 				}
 				if (outputBuffer.getNumChannels() > 1) {
-					outputBuffer.addFrom(1, 0, inputBuffer, (int) channel, 0, inputBuffer.getNumSamples(), input_volume);
+					outputBuffer.addFrom(1, 0, inputChannels[channel], outputBuffer.getNumSamples(), input_volume);
 				}
 				break;
 			}
@@ -203,301 +234,192 @@ void JammerNetzAudioEngine::calcLocalMonitoring(const AudioBuffer<float>& inputB
 	}
 }
 
-static uint8 sysexMsb(uint16 in)
-{
-	return (uint8)(in >> 7);
-}
-
-static uint8 sysexLsb(uint16 in)
-{
-	return (uint8)(in & 0x7f);
-}
-
-static MidiMessage createBossRC300ClockMessage(double bpm, MidiSignal additionalSignal)
-{
-	// Boss RC-300 loop pedal is infamous for not being able to slave to MIDI clock. Let's try with tailored sysex messages then
-	// See https://www.vguitarforums.com/smf/index.php?topic=7678.50 "RC300- Here's how to slave the RC-300's Tempo to (some) external sources"
-	uint16 length = 0x00;
-	switch (additionalSignal) {
-	case MidiSignal_Start: {
-		// We need to calculate the length, which effectively is the bar signature
-		// The RC-300 seems to work with 24 pulses per 16th note, or 24*4=96 pulses per quarter note. That is faster than the 24 ppqn we use for the
-		// MIDI clock. Anyway, let's just send it a 4 bar of 4/4 signature, which makes 16 quarter notes.
-		uint16 quarterNotesLength = 8;
-		uint16 pulsesPerQuarterNote = 96;
-		length = quarterNotesLength * pulsesPerQuarterNote;
-	}
-		break;
-	case MidiSignal_Stop:
-		// The Stop signal just uses the length 0x00 already set above
-		break;
-	default:
-		SimpleLogger::instance()->postMessageOncePerRun("Program error - got unknown MidiSignal to generate in createBossRC300ClockMessage!");
-		// fall through
-	case MidiSignal_None:
-		// Nothing to generate, return empty MidiMessage
-		return MidiMessage();
-	}
-
-	uint16 tempo = (uint16) round(bpm * 10.0f);
-	std::vector<uint8> rc300 { 0x41, 0x10, 0x00, 0x00, 0x5C, 0x12, 0x00, 0x01, 0x00, 0x00, sysexMsb(length), sysexLsb(length), sysexMsb(tempo), sysexLsb(tempo), 0x00,
-		0x00, 0x00, 0x00 };
-	uint16 checksum = 0;
-	for (size_t i = 6; i < rc300.size(); i++) {
-		checksum += rc300[i];
-	}
-	uint8 checksumByte = static_cast<uint8>((0x80 - checksum) & 0x7f);
-	rc300.push_back(checksumByte);
-	return MidiMessage::createSysExMessage(rc300.data(), (int) rc300.size());
-}
-
-static std::vector<MidiMessage> createMidiBeatMessage(double bpm, std::optional<MidiSignal> additionalSignal, bool includeBossRC300)
-{
-	// For every Midi "Beat" we create a clock message (0xf8)
-	std::vector<MidiMessage> result;
-	result.push_back(MidiMessage::midiClock());
-
-	// Send a synchronized start/stop additionally
-	if (additionalSignal.has_value()) {
-		switch (*additionalSignal) {
-		case MidiSignal_Start:
-			result.push_back(MidiMessage::midiStart());
-			break;
-		case MidiSignal_Stop:
-			result.push_back(MidiMessage::midiStop());
-			break;
-		case MidiSignal_None:
-			// No additional signal requested
-			break;
-		default:
-			jassertfalse;
-			SimpleLogger::instance()->postMessageOncePerRun("Program error: Unknown MIDI signal requested for createMidiBeatMessage");
-		}
-		if (includeBossRC300) {
-			result.push_back(createBossRC300ClockMessage(bpm, *additionalSignal));
-		}
-	}
-	return result;
-}
-
 void JammerNetzAudioEngine::process(const float* const* inputChannelData, int numInputChannels, float* const* outputChannelData,
     int numOutputChannels, int numSamples)
+{
+	if (!outputChannelData || numOutputChannels <= 0 || numSamples <= 0) {
+		return;
+	}
+	const auto callbackStart = std::chrono::steady_clock::now();
+	if (numInputChannels > JAMMERNETZ_MAX_AUDIO_CHANNELS || numOutputChannels > JAMMERNETZ_MAX_AUDIO_CHANNELS) {
+		for (int channel = 0; channel < numOutputChannels; ++channel) {
+			if (outputChannelData[channel]) {
+				juce::FloatVectorOperations::clear(outputChannelData[channel], numSamples);
+			}
+		}
+		return;
+	}
+
+	for (int offset = 0; offset < numSamples; offset += JAMMERNETZ_MAX_CALLBACK_SAMPLES) {
+		const int chunkSamples = std::min(JAMMERNETZ_MAX_CALLBACK_SAMPLES, numSamples - offset);
+		std::array<const float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> chunkInputs {};
+		std::array<float*, JAMMERNETZ_MAX_AUDIO_CHANNELS> chunkOutputs {};
+		for (int channel = 0; channel < numInputChannels; ++channel) {
+			chunkInputs[static_cast<size_t>(channel)] = inputChannelData && inputChannelData[channel] ? inputChannelData[channel] + offset : nullptr;
+		}
+		for (int channel = 0; channel < numOutputChannels; ++channel) {
+			chunkOutputs[static_cast<size_t>(channel)] = outputChannelData[channel] ? outputChannelData[channel] + offset : nullptr;
+		}
+		processChunk(chunkInputs.data(), numInputChannels, chunkOutputs.data(), numOutputChannels, chunkSamples);
+	}
+	const auto elapsed = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+		std::chrono::steady_clock::now() - callbackStart).count());
+	callbackCount_.fetch_add(1, std::memory_order_relaxed);
+	auto previousMaximum = maximumCallbackNanoseconds_.load(std::memory_order_relaxed);
+	if (elapsed > previousMaximum) {
+		maximumCallbackNanoseconds_.store(elapsed, std::memory_order_relaxed);
+	}
+	const auto sampleRate = preparedSampleRate_.load(std::memory_order_relaxed);
+	const auto deadline = sampleRate > 0.0 ? static_cast<uint64_t>(1.0e9 * static_cast<double>(numSamples) / sampleRate) : 0;
+	if (deadline > 0 && elapsed > deadline) {
+		callbackDeadlineMisses_.fetch_add(1, std::memory_order_relaxed);
+	}
+}
+
+void JammerNetzAudioEngine::processChunk(const float* const* inputChannelData, int numInputChannels, float* const* outputChannelData,
+	int numOutputChannels, int numSamples)
 {
 	float* const* constnessCorrection = const_cast<float* const*>(inputChannelData);
 	PlayoutQualityInfo qualityInfo = lastPlayoutQualityInfo_;
 	if (resetQualityInfo_.exchange(false, std::memory_order_acq_rel)) {
 		qualityInfo = PlayoutQualityInfo();
 	}
-	const auto inputState = inputState_.load(std::memory_order_acquire);
+	if (resetPlayoutRequested_.exchange(false, std::memory_order_acq_rel)) {
+		playoutBuffer_->clear();
+		isPlaying_.store(false, std::memory_order_release);
+	}
+	const auto* inputState = inputState_.load(std::memory_order_acquire);
 
 	// Measure time passed
 	measureSamplesPerTime(qualityInfo, numSamples);
 
 	// If we have at least one input channel, do something with the data!
-	if (numInputChannels > 0 && inputState && inputState->ingestBuffer && inputState->setup.channels.size() == static_cast<size_t>(numInputChannels)) {
-		// Hard disk recording
-		if (uploadRecorder_ && uploadRecorder_->isRecording()) {
-			uploadRecorder_->saveBlock(inputChannelData, numSamples);
+	bool inputChannelsValid = inputChannelData != nullptr;
+	for (int channel = 0; channel < numInputChannels && inputChannelsValid; ++channel) {
+		inputChannelsValid = inputChannelData[channel] != nullptr;
+	}
+	if (numInputChannels > 0 && inputChannelsValid && inputState && inputState->ingestBuffer
+		&& inputState->setup.channels.size() == static_cast<size_t>(numInputChannels)) {
+		if (recordingWorker_) {
+			recordingWorker_->enqueue(RecordingTarget::local, inputChannelData, numInputChannels, numSamples);
 		}
 
-		// Pump the new data into the ingest ring buffer, if it has space. Else that's possibly an assert
 		if (numSamples <= inputState->ingestBuffer->getFreeSpace()) {
 			inputState->ingestBuffer->write(constnessCorrection, numInputChannels, numSamples);
-		}
-		else {
-			jassertfalse;
+		} else {
+			inputBlocksDropped_.fetch_add(1, std::memory_order_relaxed);
 		}
 
-		// Ok, now we can exhaust the ring buffer by reading network packet sized chunks and sending them to the server one by one
 		while (inputState->ingestBuffer->getNumReady() >= SAMPLE_BUFFER_SIZE) {
-			// Allocate an audio buffer and read a buffer full from the ring buffer
-			auto audioBuffer = std::make_shared<AudioBuffer<float>>(numInputChannels, SAMPLE_BUFFER_SIZE);
-			inputState->ingestBuffer->read(audioBuffer->getArrayOfWritePointers(), numInputChannels, SAMPLE_BUFFER_SIZE);
-
-			// Send it to pitch detection
-			tuner_->detectPitch(audioBuffer);
-
-			// Measure the peak values for each channel
-			meterSource_.measureBlock(*audioBuffer);
-
-			// Send the MAG, RMS values and the pitch to the server, which will forward it to the other clients so they can show my levels even if they have only the mixed audio
-			JammerNetzChannelSetup outgoingSetup = inputState->setup;
-			for (size_t c = 0; c < static_cast<size_t>(numInputChannels); c++) {
-				outgoingSetup.channels[c].mag = meterSource_.getMaxLevel(static_cast<int>(c));
-				outgoingSetup.channels[c].rms = meterSource_.getRMSLevel(static_cast<int>(c));
-				outgoingSetup.channels[c].pitch = tuner_->getPitch(c);
-			}
-
-			// Get play-along data. The MIDI Buffer should be ready to be played out now, but we will only look at the text events for now
-			/*if (false) {
-				std::vector<MidiMessage> buffer;
-				midiPlayalong_->fillNextMidiBuffer(buffer, numSamples);
-				if (!buffer.empty()) {
-					// The whole buffer is just a few milliseconds - take only the last text event
-					MidiMessage &message = buffer.back();
-					if (message.isTextMetaEvent()) {
-						currentText_ = message.getTextFromTextMetaEvent().toStdString();
-					}
+			if (transmitWorker_ && transmitWorker_->hasCapacity()) {
+				transmitWorker_->enqueueFrom(*inputState->ingestBuffer, numInputChannels,
+					clientBpm_.readOnce(), midiSignalToSend_.readOnce());
+			} else {
+				inputState->ingestBuffer->discard(SAMPLE_BUFFER_SIZE);
+				if (transmitWorker_) {
+					transmitWorker_->recordDroppedFrame();
 				}
-			}*/
-
-			ControlData controllers;
-			controllers.bpm = clientBpm_.readOnce();
-			controllers.midiSignal = midiSignalToSend_.readOnce();
-			if (auto* sender = session_.sender()) {
-				sender->sendData(outgoingSetup, audioBuffer, controllers); //TODO offload the real sending to a different thread
 			}
 		}
 	}
 
 	// Create a better access structure for the output data
-	AudioBuffer<float> outputBuffer(outputChannelData, numOutputChannels, numSamples);
-	AudioBuffer<float> inputBufferNotOwned(constnessCorrection, numInputChannels, numSamples);
-
-	// Don't start playing before the desired play-out buffer size is reached
-	if (!isPlaying_ && playBuffer_.size() >= minPlayoutBufferLength_) {
-		isPlaying_ = true;
-	}
-	else if (playBuffer_.size() > maxPlayoutBufferLength_) {
-		// That's too many packages in our buffer, where did those come from? Did the server deliver too many packets/did our playback stop?
-		// Reduce the length of the queue until it is the right size, throuw away audio that is too old to be played out
-		std::shared_ptr<JammerNetzAudioData> data;
-		while (playBuffer_.size() > CLIENT_PLAYOUT_JITTER_BUFFER) {
-			qualityInfo.discardedPackageCounter_++;
-			bool isFillIn;
-			playBuffer_.try_pop(data, isFillIn);
+	for (int channel = 0; channel < numOutputChannels; ++channel) {
+		if (outputChannelData[channel]) {
+			juce::FloatVectorOperations::clear(outputChannelData[channel], numSamples);
 		}
 	}
+	int engineOutputChannels = 0;
+	while (engineOutputChannels < std::min(numOutputChannels, 2) && outputChannelData[engineOutputChannels]) {
+		++engineOutputChannels;
+	}
+	AudioBuffer<float> outputBuffer(outputChannelData, engineOutputChannels, numSamples);
 
 	// Prepare the output buffer with the local monitoring signal
 	if (inputState) {
-		calcLocalMonitoring(inputBufferNotOwned, outputBuffer, inputState->setup);
-	}
-	else {
-		outputBuffer.clear();
+		calcLocalMonitoring(inputChannelData, numInputChannels, outputBuffer, inputState->setup);
 	}
 
 	// For playout, we have to have enough bytes in the out ringbuffer to fill the output audio block.
 	// Let's see if we have enough data from the network!
 
-	while (isPlaying_ && playoutBuffer_->getNumReady() < numSamples) {
-		// We need to produce a network package to fill up the playout ring buffer
-		std::shared_ptr<JammerNetzAudioData> toPlay;
-		bool isFillIn;
-		if (playBuffer_.try_pop(toPlay, isFillIn)) {
-			qualityInfo.currentPlayQueueLength_ = playBuffer_.size();
-			// Ok, we have an Audio buffer to play. Hand over the data to the playback!
-			if (toPlay && toPlay->audioBuffer()) {
-				// Calculate the to-play latency
-				qualityInfo.toPlayLatency_ = Time::getMillisecondCounterHiRes() - toPlay->timestamp();
-				playoutBuffer_->write(toPlay->audioBuffer()->getArrayOfReadPointers(),
-					toPlay->audioBuffer()->getNumChannels(),
-					toPlay->audioBuffer()->getNumSamples());
-			}
-			else {
-				// That would be considered a programming error, I shall not enqueue nullptr
-				jassert(false);
-				break;
-			}
-
-			// Check if we are tasked to generate a MIDI signal
-			if (toPlay->midiSignal() != MidiSignal_None) {
-				// This might overwrite a signal not yet generated, because the next F8 clock has not been generated
-				midiSignalToGenerate_.setValue(toPlay->midiSignal());
-			}
-
-			double bpm = toPlay->bpm();
-			serverBpm_ = bpm;
-			if (auto midiSendThread = midiSendThread_.load(std::memory_order_acquire)) {
-				// Play a MIDI clock at the speed given
-				constexpr double pulsesPerQuarterNote = 24.0; // This is fairly standard
-				double pulsesPerSecond = bpm * pulsesPerQuarterNote / 60.0;
-				double samplesPerSecond = static_cast<double>(SAMPLE_RATE);
-				double samplesPerPulse = samplesPerSecond / pulsesPerSecond;
-				jassert(samplesPerPulse > SAMPLE_BUFFER_SIZE); // Else it gets jitery
-
-				// Determine the server time for the first sample of this package
-				uint64 serverTimeinSamples = toPlay->serverTime();
-				const auto serverTimeInSamplesAsDouble = static_cast<double>(serverTimeinSamples);
-				double bufferStartPulseNumber = floor(serverTimeInSamplesAsDouble / samplesPerPulse);
-				double bufferEndPulseNumber = floor((serverTimeInSamplesAsDouble + static_cast<double>(SAMPLE_BUFFER_SIZE)) / samplesPerPulse);
-				if (bufferEndPulseNumber - bufferStartPulseNumber > 1e-6) {
-					// A Pulse must be sent! When in this buffer is the pulse due?
-					double pulseFractionInSamples = bufferEndPulseNumber * samplesPerPulse - serverTimeInSamplesAsDouble;
-					jassert(pulseFractionInSamples <= SAMPLE_BUFFER_SIZE);
-					auto signalToGenerate = midiSignalToGenerate_.readOnce();
-					midiSendThread->enqueue(std::chrono::nanoseconds(int(1e9 * pulseFractionInSamples / SAMPLE_RATE)), createMidiBeatMessage(bpm, signalToGenerate, true));
-				}
-			}
-
-			// Check if the slider wasn't updated for a while, then take the server value and update the slider
-			const auto now = std::chrono::steady_clock::now();
-			const auto lastMovedTicks = bpmSliderLastMovedTicks_.load(std::memory_order_acquire);
-			const auto lastMoved = std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(lastMovedTicks));
-			if (lastMovedTicks == 0 || now - lastMoved > std::chrono::seconds(1)) {
-				pendingServerBpm_.store((float) bpm, std::memory_order_release);
-				ignoreNextServerBpmChange_.store(true, std::memory_order_release);
-				serverBpmUpdate_.setValue(static_cast<float>(bpm));
-				bpmSliderLastMovedTicks_.store(now.time_since_epoch().count(), std::memory_order_release);
-			}
-		}
-		else {
-			// Buffer underrun
+	while (receiveWorker_ && playoutBuffer_->getNumReady() < numSamples) {
+		RemoteAudioFrame frame;
+		if (!receiveWorker_->tryPop(frame)) {
 			break;
 		}
+		if (frame.generation != expectedRemoteGeneration_.load(std::memory_order_acquire)) {
+			continue;
+		}
+		std::array<const float*, 2> pointers { frame.samples[0].data(), frame.samples[1].data() };
+		playoutBuffer_->write(pointers.data(), 2, SAMPLE_BUFFER_SIZE);
+		qualityInfo.toPlayLatency_ = Time::getMillisecondCounterHiRes() - frame.sourceTimestamp;
+	}
+	qualityInfo.currentPlayQueueLength_ = receiveWorker_ ? static_cast<uint64>(receiveWorker_->readyFrames()) : 0;
+	qualityInfo.discardedPackageCounter_ = receiveWorker_ ? receiveWorker_->discardedFrames() : 0;
+	if (!isPlaying_.load(std::memory_order_acquire) && playoutBuffer_->getNumReady() >= numSamples) {
+		isPlaying_.store(true, std::memory_order_release);
 	}
 
-	if (isPlaying_) {
+	if (isPlaying_.load(std::memory_order_acquire)) {
 		if (playoutBuffer_->getNumReady() < numSamples) {
-			// This is a serious problem - either the server never started to send data, or we have a buffer underflow.
 			qualityInfo.playUnderruns_++;
-			isPlaying_ = false;
+			isPlaying_.store(false, std::memory_order_release);
+			playoutBuffer_->clear();
+			if (receiveWorker_) {
+				receiveWorker_->requestRebuffer();
+			}
 		}
 		else {
-			// We have Audio data to play! Make sure it is the correct size
-			AudioBuffer<float> sessionAudio(2, numSamples);
-			playoutBuffer_->read(sessionAudio.getArrayOfWritePointers(), 2, numSamples);
+			std::array<float*, 2> scratchPointers { remoteScratch_.getWritePointer(0), remoteScratch_.getWritePointer(1) };
+			playoutBuffer_->read(scratchPointers.data(), 2, numSamples);
 
 			auto [_, remoteVolume] = calcMonitorGain(monitorBalance_.load(std::memory_order_relaxed));
 			float volume = (float) (remoteVolume * masterVolume_);
 			for (int c = 0; c < std::min(2, outputBuffer.getNumChannels()); c++) {
-				outputBuffer.addFrom(c, 0, sessionAudio.getReadPointer(c), numSamples, volume);
+				outputBuffer.addFrom(c, 0, remoteScratch_.getReadPointer(c), numSamples, volume);
 			}
 		}
-
-		// Calculate the RMS and mag displays for the other session participants
-		auto session = session_.getCurrentSessionSetup();
-		std::vector<float> magnitudes;
-		std::vector<float> rmss;
-		for (const auto& channel : session.channels) {
-			magnitudes.push_back(channel.mag);
-			rmss.push_back(channel.rms);
-		}
-		sessionMeterSource_.setBlockMeasurement(session.channels.size(), magnitudes, rmss);
 	}
 
-	outMeterSource_.measureBlock(outputBuffer);
-	if (masterRecorder_ && masterRecorder_->isRecording()) {
-		masterRecorder_->saveBlock(outputBuffer.getArrayOfReadPointers(), numSamples);
+	std::array<float*, 2> meterPointers {
+		engineOutputChannels > 0 ? outputChannelData[0] : silentMeterChannel_.data(),
+		engineOutputChannels > 1 ? outputChannelData[1] : silentMeterChannel_.data()
+	};
+	AudioBuffer<float> meterBuffer(meterPointers.data(), 2, numSamples);
+	outMeterSource_.measureBlock(meterBuffer);
+	if (recordingWorker_) {
+		recordingWorker_->enqueue(RecordingTarget::master, outputBuffer.getArrayOfReadPointers(), engineOutputChannels, numSamples);
 	}
 
-	// Make the calculated quality info available for an interested consumer
 	lastPlayoutQualityInfo_ = qualityInfo;
-	playoutQualityInfo_.push(qualityInfo);
+	publishedQueueLength_.store(qualityInfo.currentPlayQueueLength_, std::memory_order_relaxed);
+	publishedUnderruns_.store(qualityInfo.playUnderruns_, std::memory_order_relaxed);
+	publishedDiscarded_.store(qualityInfo.discardedPackageCounter_, std::memory_order_relaxed);
+	publishedLatency_.store(qualityInfo.toPlayLatency_, std::memory_order_relaxed);
+	publishedSampleRate_.store(qualityInfo.measuredSampleRate, std::memory_order_relaxed);
+	completedAudioEpoch_.fetch_add(1, std::memory_order_release);
 }
 
 void JammerNetzAudioEngine::prepare(double sampleRate, int maximumBlockSize)
 {
-	ignoreUnused(sampleRate, maximumBlockSize);
+	ignoreUnused(maximumBlockSize);
+	jassert(maximumBlockSize <= JAMMERNETZ_MAX_CALLBACK_SAMPLES);
+	preparedSampleRate_.store(sampleRate, std::memory_order_relaxed);
 	lastPlayoutQualityInfo_ = PlayoutQualityInfo();
+	resetPlayoutRequested_.store(true, std::memory_order_release);
 }
 
 void JammerNetzAudioEngine::release()
 {
+	resetPlayoutRequested_.store(true, std::memory_order_release);
 }
 
 void JammerNetzAudioEngine::setChannelSetup(JammerNetzChannelSetup const &channelSetup)
 {
+	if (transmitWorker_) {
+		transmitWorker_->setChannelSetup(channelSetup);
+	}
 	const auto previousState = inputState_.load(std::memory_order_acquire);
 	if (previousState && previousState->setup.isEqualEnough(channelSetup)) {
 		return;
@@ -512,7 +434,15 @@ void JammerNetzAudioEngine::setChannelSetup(JammerNetzChannelSetup const &channe
 		}
 	}
 
-	inputState_.store(std::make_shared<const InputState>(InputState { channelSetup, std::move(ingestBuffer) }), std::memory_order_release);
+	const auto completedEpoch = completedAudioEpoch_.load(std::memory_order_acquire);
+	retiredInputStates_.erase(std::remove_if(retiredInputStates_.begin(), retiredInputStates_.end(), [completedEpoch](const RetiredInputState& retired) {
+		return retired.retireEpoch < completedEpoch;
+	}), retiredInputStates_.end());
+	if (configuredInputState_) {
+		retiredInputStates_.push_back({ configuredInputState_, completedEpoch });
+	}
+	configuredInputState_ = std::make_shared<const InputState>(InputState { channelSetup, std::move(ingestBuffer) });
+	inputState_.store(configuredInputState_.get(), std::memory_order_release);
 	if (channelCountChanged && midiRecorder_) {
 		midiRecorder_->startRecording();
 	}
@@ -520,12 +450,12 @@ void JammerNetzAudioEngine::setChannelSetup(JammerNetzChannelSetup const &channe
 
 FFAU::LevelMeterSource* JammerNetzAudioEngine::getMeterSource()
 {
-	return &meterSource_;
+	return transmitWorker_ ? transmitWorker_->meterSource() : nullptr;
 }
 
 FFAU::LevelMeterSource* JammerNetzAudioEngine::getSessionMeterSource()
 {
-	return &sessionMeterSource_;
+	return receiveWorker_ ? receiveWorker_->meterSource() : nullptr;
 }
 
 FFAU::LevelMeterSource* JammerNetzAudioEngine::getOutputMeterSource()
@@ -545,10 +475,36 @@ MidiPlayAlong *JammerNetzAudioEngine::getPlayalong()
 
 PlayoutQualityInfo JammerNetzAudioEngine::getPlayoutQualityInfo()
 {
-	// Return the latest QualityInfo
 	PlayoutQualityInfo latest;
-	while (playoutQualityInfo_.try_pop(latest));
+	latest.currentPlayQueueLength_ = publishedQueueLength_.load(std::memory_order_relaxed);
+	latest.playUnderruns_ = publishedUnderruns_.load(std::memory_order_relaxed);
+	latest.discardedPackageCounter_ = publishedDiscarded_.load(std::memory_order_relaxed);
+	latest.toPlayLatency_ = publishedLatency_.load(std::memory_order_relaxed);
+	latest.measuredSampleRate = publishedSampleRate_.load(std::memory_order_relaxed);
 	return latest;
+}
+
+RealtimeWorkerStats JammerNetzAudioEngine::getRealtimeWorkerStats() const
+{
+	RealtimeWorkerStats stats;
+	stats.callbackCount = callbackCount_.load(std::memory_order_relaxed);
+	stats.maximumCallbackNanoseconds = maximumCallbackNanoseconds_.load(std::memory_order_relaxed);
+	stats.callbackDeadlineMisses = callbackDeadlineMisses_.load(std::memory_order_relaxed);
+	stats.inputBlocksDropped = inputBlocksDropped_.load(std::memory_order_relaxed);
+	if (transmitWorker_) {
+		stats.transmitFramesQueued = transmitWorker_->enqueuedFrames();
+		stats.transmitFramesSent = transmitWorker_->sentFrames();
+		stats.transmitFramesDropped = transmitWorker_->droppedFrames();
+	}
+	if (receiveWorker_) {
+		stats.receiveFramesDiscarded = receiveWorker_->discardedFrames();
+		stats.receiveQueueOverruns = receiveWorker_->outputQueueOverruns();
+	}
+	if (recordingWorker_) {
+		stats.recordingFramesWritten = recordingWorker_->writtenFrames();
+		stats.recordingFramesDropped = recordingWorker_->droppedFrames();
+	}
+	return stats;
 }
 
 uint64 JammerNetzAudioEngine::currentBufferSize() const
@@ -564,7 +520,7 @@ int JammerNetzAudioEngine::currentPacketSize()
 
 std::string JammerNetzAudioEngine::currentReceptionQuality() const
 {
-	return playBuffer_.qualityStatement();
+	return receiveWorker_ ? receiveWorker_->qualityStatement() : std::string();
 }
 
 bool JammerNetzAudioEngine::isReceivingData()
@@ -579,7 +535,7 @@ double JammerNetzAudioEngine::currentRTT()
 
 float JammerNetzAudioEngine::channelPitch(size_t channel) const
 {
-	return tuner_->getPitch(channel);
+	return transmitWorker_ ? transmitWorker_->channelPitch(channel) : 0.0f;
 }
 
 float JammerNetzAudioEngine::sessionPitch(size_t channel) {

--- a/Client/Source/JammerNetzAudioEngine.cpp
+++ b/Client/Source/JammerNetzAudioEngine.cpp
@@ -177,10 +177,10 @@ void JammerNetzAudioEngine::setMidiSignalToSend(MidiSignal signal)
 void JammerNetzAudioEngine::newServer()
 {
 	resetQualityInfo_.store(true, std::memory_order_release);
-	resetPlayoutRequested_.store(true, std::memory_order_release);
 	if (receiveWorker_) {
 		expectedRemoteGeneration_.store(receiveWorker_->requestReset(), std::memory_order_release);
 	}
+	resetPlayoutRequested_.store(true, std::memory_order_release);
 }
 
 void JammerNetzAudioEngine::measureSamplesPerTime(PlayoutQualityInfo &qualityInfo, int numSamples) const {
@@ -340,8 +340,10 @@ void JammerNetzAudioEngine::processChunk(const float* const* inputChannelData, i
 
 		while (inputState->ingestBuffer->getNumReady() >= SAMPLE_BUFFER_SIZE) {
 			if (transmitWorker_ && transmitWorker_->hasCapacity()) {
-				transmitWorker_->enqueueFrom(*inputState->ingestBuffer, numInputChannels,
-					clientBpm_.readOnce(), midiSignalToSend_.readOnce());
+				if (!transmitWorker_->enqueueFrom(*inputState->ingestBuffer, numInputChannels,
+						clientBpm_.readOnce(), midiSignalToSend_.readOnce())) {
+					inputState->ingestBuffer->discard(SAMPLE_BUFFER_SIZE);
+				}
 			} else {
 				inputState->ingestBuffer->discard(SAMPLE_BUFFER_SIZE);
 				if (transmitWorker_) {
@@ -432,7 +434,6 @@ void JammerNetzAudioEngine::processChunk(const float* const* inputChannelData, i
 void JammerNetzAudioEngine::prepare(double sampleRate, int maximumBlockSize)
 {
 	ignoreUnused(maximumBlockSize);
-	jassert(maximumBlockSize <= JAMMERNETZ_MAX_CALLBACK_SAMPLES);
 	preparedSampleRate_.store(sampleRate, std::memory_order_relaxed);
 	lastPlayoutQualityInfo_ = PlayoutQualityInfo();
 	resetPlayoutRequested_.store(true, std::memory_order_release);

--- a/Client/Source/JammerNetzAudioEngine.h
+++ b/Client/Source/JammerNetzAudioEngine.h
@@ -10,21 +10,21 @@
 
 #include "IncludeFFMeters.h"
 
-#include "Pool.h"
 #include "RingBuffer.h"
 #include "JammerNetzSession.h"
 
-#include "PacketStreamQueue.h"
+#include "AudioReceiveWorker.h"
+#include "AudioRecordingWorker.h"
+#include "AudioTransmitWorker.h"
 #include "Recorder.h"
-#include "Tuner.h"
 #include "MidiRecorder.h"
 #include "MidiPlayAlong.h"
 #include "MidiSendThread.h"
 
 #include "AtomicSharedPtr.h"
 
+#include <array>
 #include <chrono>
-#include <tbb/concurrent_queue.h>
 
 struct PlayoutQualityInfo {
 	PlayoutQualityInfo()
@@ -40,6 +40,20 @@ struct PlayoutQualityInfo {
 	std::chrono::time_point<std::chrono::steady_clock> startTime_;
 	std::chrono::time_point<std::chrono::steady_clock> lastTime_;
 	double measuredSampleRate; // in Hz
+};
+
+struct RealtimeWorkerStats {
+	uint64_t callbackCount { 0 };
+	uint64_t maximumCallbackNanoseconds { 0 };
+	uint64_t callbackDeadlineMisses { 0 };
+	uint64_t inputBlocksDropped { 0 };
+	uint64_t transmitFramesQueued { 0 };
+	uint64_t transmitFramesSent { 0 };
+	uint64_t transmitFramesDropped { 0 };
+	uint64_t receiveFramesDiscarded { 0 };
+	uint64_t receiveQueueOverruns { 0 };
+	uint64_t recordingFramesWritten { 0 };
+	uint64_t recordingFramesDropped { 0 };
 };
 
 template <typename T>
@@ -109,6 +123,7 @@ public:
 
 	// Statistics
 	PlayoutQualityInfo getPlayoutQualityInfo();
+	RealtimeWorkerStats getRealtimeWorkerStats() const;
 
 	uint64 currentBufferSize() const;
 	int currentPacketSize();
@@ -129,35 +144,45 @@ private:
 		JammerNetzChannelSetup setup;
 		std::shared_ptr<RingBuffer> ingestBuffer;
 	};
+	struct RetiredInputState {
+		std::shared_ptr<const InputState> state;
+		uint64_t retireEpoch { 0 };
+	};
 
 	void measureSamplesPerTime(PlayoutQualityInfo &qualityInfo, int numSamples) const;
+	void processChunk(const float* const* inputChannelData, int numInputChannels, float* const* outputChannelData,
+		int numOutputChannels, int numSamples);
 
-	void calcLocalMonitoring(const AudioBuffer<float>& inputBuffer, AudioBuffer<float>& outputBuffer, const JammerNetzChannelSetup& channelSetup);
+	void calcLocalMonitoring(const float* const* inputChannels, int numInputChannels, AudioBuffer<float>& outputBuffer,
+		const JammerNetzChannelSetup& channelSetup);
 
 	JammerNetzSession& session_;
 	juce::File recordingDirectory_;
 
-	AtomicSharedPtr<const InputState> inputState_;
+	std::atomic<const InputState*> inputState_ { nullptr };
+	std::shared_ptr<const InputState> configuredInputState_;
+	std::vector<RetiredInputState> retiredInputStates_;
+	std::atomic<uint64_t> completedAudioEpoch_ { 0 };
 	std::unique_ptr<RingBuffer> playoutBuffer_;
+	juce::AudioBuffer<float> remoteScratch_;
+	std::array<float, JAMMERNETZ_MAX_CALLBACK_SAMPLES> silentMeterChannel_ {};
 
-	PacketStreamQueue playBuffer_;
-	std::atomic_bool isPlaying_;
-	std::atomic_bool resetQualityInfo_;
+	std::atomic_bool isPlaying_ { false };
+	std::atomic_bool resetQualityInfo_ { false };
+	std::atomic_bool resetPlayoutRequested_ { false };
+	std::atomic<uint64_t> expectedRemoteGeneration_ { 0 };
 	std::atomic_uint64_t minPlayoutBufferLength_;
 	std::atomic_uint64_t maxPlayoutBufferLength_;
 	std::atomic<double> masterVolume_;
 	std::atomic<double> monitorBalance_;
-	std::atomic<bool> monitorIsLocal_;
+	std::atomic<bool> monitorIsLocal_ { false };
 	ReadOnceLatch<float> clientBpm_;
 	std::atomic<double> serverBpm_;
 	std::atomic<bool> ignoreNextServerBpmChange_;
 	std::atomic<float> pendingServerBpm_;
-	ReadOnceLatch<float> serverBpmUpdate_;
 	std::atomic<int64_t> bpmSliderLastMovedTicks_;
 	std::string currentText_;
 
-	FFAU::LevelMeterSource meterSource_; // This is for peak metering
-	FFAU::LevelMeterSource sessionMeterSource_; // This is to display the complete session peak meters
 	FFAU::LevelMeterSource outMeterSource_; // This is for peak metering the output
 
 	std::shared_ptr<Recorder> uploadRecorder_;
@@ -165,14 +190,21 @@ private:
 	std::unique_ptr<MidiRecorder> midiRecorder_;
 	std::unique_ptr<MidiPlayAlong> midiPlayalong_;
 	AtomicSharedPtr<MidiSendThread> midiSendThread_;
+	std::unique_ptr<AudioTransmitWorker> transmitWorker_;
+	std::unique_ptr<AudioReceiveWorker> receiveWorker_;
+	std::unique_ptr<AudioRecordingWorker> recordingWorker_;
 
 	ReadOnceLatch<MidiSignal> midiSignalToSend_;
-	ReadOnceLatch<MidiSignal> midiSignalToGenerate_;
-
-	std::unique_ptr<Tuner> tuner_;
-
-	// Use this to hand out statistics from the audio/real time callback to other interested threads
-	tbb::concurrent_queue<PlayoutQualityInfo> playoutQualityInfo_;
 	PlayoutQualityInfo lastPlayoutQualityInfo_;
+	std::atomic<uint64_t> publishedQueueLength_ { 0 };
+	std::atomic<uint64_t> publishedUnderruns_ { 0 };
+	std::atomic<uint64_t> publishedDiscarded_ { 0 };
+	std::atomic<double> publishedLatency_ { 0.0 };
+	std::atomic<double> publishedSampleRate_ { 0.0 };
+	std::atomic<double> preparedSampleRate_ { SAMPLE_RATE };
+	std::atomic<uint64_t> callbackCount_ { 0 };
+	std::atomic<uint64_t> maximumCallbackNanoseconds_ { 0 };
+	std::atomic<uint64_t> callbackDeadlineMisses_ { 0 };
+	std::atomic<uint64_t> inputBlocksDropped_ { 0 };
 
 };

--- a/Client/Source/JammerNetzAudioEngine.h
+++ b/Client/Source/JammerNetzAudioEngine.h
@@ -31,7 +31,7 @@ struct PlayoutQualityInfo {
 		: currentPlayQueueLength_(0), playUnderruns_(0), discardedPackageCounter_(0),
 		toPlayLatency_(0.0), numSamplesSinceStart_(-1), measuredSampleRate(0.0) {}
 
-	uint64 currentPlayQueueLength_;
+	uint64 currentPlayQueueLength_; // Prepared PCM frames waiting in AudioReceiveWorker.
 	uint64 playUnderruns_;
 	uint64 discardedPackageCounter_;
 	double toPlayLatency_; // in ms

--- a/Client/Source/JammerNetzAudioEngineTests.cpp
+++ b/Client/Source/JammerNetzAudioEngineTests.cpp
@@ -210,4 +210,14 @@ TEST(JammerNetzAudioEngineTest, BoundsReceiveBurstsBeforeTheWorkerStarts)
 	EXPECT_EQ(stats.receiveFramesDiscarded, 88u);
 }
 
+TEST(MidiSendThreadTest, ShutdownInterruptsAFutureScheduledMessage)
+{
+	MidiSendThread sender(std::vector<juce::MidiDeviceInfo> {});
+	ASSERT_TRUE(sender.enqueue(std::chrono::seconds(5), { juce::MidiMessage::midiClock() }));
+	juce::Thread::sleep(20);
+	const auto started = std::chrono::steady_clock::now();
+	sender.shutdown();
+	EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::milliseconds(500));
+}
+
 } // namespace

--- a/Client/Source/JammerNetzAudioEngineTests.cpp
+++ b/Client/Source/JammerNetzAudioEngineTests.cpp
@@ -6,6 +6,8 @@
 
 #include "JammerNetzAudioEngine.h"
 #include "BuffersConfig.h"
+#include "BoundedSpscQueue.h"
+#include "PacketStreamQueue.h"
 
 #include <gtest/gtest.h>
 
@@ -38,9 +40,9 @@ TEST(JammerNetzAudioEngineTest, ProcessesSyntheticBlocksWithoutAnAudioDevice)
 	engine.setLocalMonitoring(true);
 	engine.setMasterVolume(1.0);
 	engine.setMonitorBalance(0.0);
-	engine.prepare(48000.0, 512);
+	engine.prepare(48000.0, 1024);
 
-	for (const int blockSize : std::array<int, 3> { 32, 128, 256 }) {
+	for (const int blockSize : std::array<int, 6> { 32, 64, 128, 256, 512, 1024 }) {
 		std::vector<float> input(static_cast<size_t>(blockSize), 1.0f);
 		std::vector<float> left(static_cast<size_t>(blockSize), 0.0f);
 		std::vector<float> right(static_cast<size_t>(blockSize), 0.0f);
@@ -55,6 +57,9 @@ TEST(JammerNetzAudioEngineTest, ProcessesSyntheticBlocksWithoutAnAudioDevice)
 		EXPECT_NEAR(left.back(), expectedGain, 1.0e-5f);
 		EXPECT_NEAR(right.back(), expectedGain, 1.0e-5f);
 	}
+	const auto realtimeStats = engine.getRealtimeWorkerStats();
+	EXPECT_EQ(realtimeStats.callbackCount, 6u);
+	EXPECT_GT(realtimeStats.maximumCallbackNanoseconds, 0u);
 
 	engine.release();
 }
@@ -91,6 +96,7 @@ TEST(JammerNetzAudioEngineTest, MixesASimulatedRemoteFrame)
 {
 	JammerNetzSession session;
 	JammerNetzAudioEngine engine(session, juce::File());
+	engine.start();
 	engine.setPlayoutBufferRange(1, 4);
 	engine.setLocalMonitoring(false);
 
@@ -112,11 +118,93 @@ TEST(JammerNetzAudioEngineTest, MixesASimulatedRemoteFrame)
 	float unusedInput = 0.0f;
 	const float* inputs[] { &unusedInput };
 	float* outputs[] { left.data(), right.data() };
-	engine.process(inputs, 0, outputs, 2, SAMPLE_BUFFER_SIZE);
+	for (int attempt = 0; attempt < 100 && left.front() == 0.0f; ++attempt) {
+		engine.process(inputs, 0, outputs, 2, SAMPLE_BUFFER_SIZE);
+		juce::Thread::sleep(2);
+	}
 
 	const float expectedGain = static_cast<float>(0.25 * std::sqrt(0.5));
 	EXPECT_NEAR(left.front(), expectedGain, 1.0e-5f);
 	EXPECT_NEAR(right.front(), expectedGain, 1.0e-5f);
+	engine.shutdown();
+}
+
+TEST(BoundedSpscQueueTest, RejectsWritesWhenFullAndPreservesOrder)
+{
+	BoundedSpscQueue<int> queue(2);
+	EXPECT_TRUE(queue.tryWrite([](int& value) { value = 10; }));
+	EXPECT_TRUE(queue.tryWrite([](int& value) { value = 20; }));
+	EXPECT_FALSE(queue.tryWrite([](int& value) { value = 30; }));
+	int value = 0;
+	EXPECT_TRUE(queue.tryRead([&](int& queued) { value = queued; }));
+	EXPECT_EQ(value, 10);
+	EXPECT_TRUE(queue.tryRead([&](int& queued) { value = queued; }));
+	EXPECT_EQ(value, 20);
+	EXPECT_FALSE(queue.tryRead([&](int& queued) { value = queued; }));
+}
+
+TEST(PacketStreamQueueTest, ResetAcceptsANewPacketSequence)
+{
+	PacketStreamQueue queue("test");
+	auto audio = std::make_shared<juce::AudioBuffer<float>>(2, SAMPLE_BUFFER_SIZE);
+	JammerNetzChannelSetup setup(false, {
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left),
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right)
+	});
+	const auto makePacket = [&](uint64 counter) {
+		return std::make_shared<JammerNetzAudioData>(
+			counter, 0.0, setup, SAMPLE_RATE, 120.0f, MidiSignal_None, audio, nullptr);
+	};
+	std::shared_ptr<JammerNetzAudioData> popped;
+	bool fillIn = false;
+
+	ASSERT_TRUE(queue.push(makePacket(42)));
+	ASSERT_TRUE(queue.try_pop(popped, fillIn));
+	EXPECT_EQ(popped->messageCounter(), 42u);
+	queue.reset();
+	ASSERT_TRUE(queue.push(makePacket(1)));
+	ASSERT_TRUE(queue.try_pop(popped, fillIn));
+	EXPECT_EQ(popped->messageCounter(), 1u);
+	EXPECT_FALSE(fillIn);
+}
+
+TEST(JammerNetzAudioEngineTest, DropsFramesInsteadOfBlockingWhenTransmitWorkerIsStalled)
+{
+	JammerNetzSession session;
+	JammerNetzAudioEngine engine(session, juce::File());
+	engine.setChannelSetup(monoLocalSetup());
+	std::array<float, SAMPLE_BUFFER_SIZE> input {};
+	std::array<float, SAMPLE_BUFFER_SIZE> left {};
+	std::array<float, SAMPLE_BUFFER_SIZE> right {};
+	const float* inputs[] { input.data() };
+	float* outputs[] { left.data(), right.data() };
+	for (int block = 0; block < 100; ++block) {
+		engine.process(inputs, 1, outputs, 2, SAMPLE_BUFFER_SIZE);
+	}
+	const auto stats = engine.getRealtimeWorkerStats();
+	EXPECT_EQ(stats.transmitFramesQueued, 64u);
+	EXPECT_GT(stats.transmitFramesDropped, 0u);
+}
+
+TEST(JammerNetzAudioEngineTest, BoundsReceiveBurstsBeforeTheWorkerStarts)
+{
+	JammerNetzSession session;
+	JammerNetzAudioEngine engine(session, juce::File());
+	auto audio = std::make_shared<juce::AudioBuffer<float>>(2, SAMPLE_BUFFER_SIZE);
+	JammerNetzChannelSetup setup(false, {
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left),
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right)
+	});
+	auto packet = std::make_shared<JammerNetzAudioData>(
+		1, 0.0, setup, SAMPLE_RATE, 120.0f, MidiSignal_None, audio, nullptr);
+
+	for (int frame = 0; frame < 600; ++frame) {
+		engine.enqueueRemoteAudio(packet);
+	}
+
+	const auto stats = engine.getRealtimeWorkerStats();
+	EXPECT_EQ(stats.receiveQueueOverruns, 88u);
+	EXPECT_EQ(stats.receiveFramesDiscarded, 88u);
 }
 
 } // namespace

--- a/Client/Source/MainComponent.cpp
+++ b/Client/Source/MainComponent.cpp
@@ -306,7 +306,7 @@ void MainComponent::timerCallback()
 	status << "Input latency: " << inputLatency << "ms" << std::endl;
 	status << "Output latency: " << outputLatency << "ms" << std::endl;
 	status << "Roundtrip: " << audioService_->currentRTT() << "ms" << std::endl;
-	status << "PlayQ: " << qualityInfo.currentPlayQueueLength_ << std::endl;
+	status << "PreparedQ: " << qualityInfo.currentPlayQueueLength_ << std::endl;
 	status << "Discarded: " << qualityInfo.discardedPackageCounter_ << std::endl;
 	status << "Latency without I/O: " << qualityInfo.toPlayLatency_ << " ms" << std::endl;
 	status << "Total: " <<  qualityInfo.toPlayLatency_ + inputLatency + outputLatency << " ms" << std::endl;

--- a/Client/Source/MidiSendThread.cpp
+++ b/Client/Source/MidiSendThread.cpp
@@ -62,8 +62,11 @@ void MidiSendThread::run()
 			bool sentAny = false;
 			while (midiMessages.tryRead([&](MessageQueueItem& item) {
 				// Wait until the time has come
-				while (std::chrono::high_resolution_clock::now() < item.whenToSend) {
+				while (!threadShouldExit() && std::chrono::high_resolution_clock::now() < item.whenToSend) {
 					juce::Thread::yield();
+				}
+				if (threadShouldExit()) {
+					return;
 				}
 				// Send the F8 MIDI Clock message to all devices registered
 				for (auto &out : f8_outputs) {

--- a/Client/Source/MidiSendThread.cpp
+++ b/Client/Source/MidiSendThread.cpp
@@ -27,11 +27,22 @@ MidiSendThread::~MidiSendThread()
 	stopThread(1000);
 }
 
-void MidiSendThread::enqueue(std::chrono::high_resolution_clock::duration fromNow, std::vector<MidiMessage> const &messages)
+bool MidiSendThread::enqueue(std::chrono::high_resolution_clock::duration fromNow, std::vector<MidiMessage> const &messages)
 {
-	ignoreUnused(fromNow);
 	auto now = std::chrono::high_resolution_clock::now() + fromNow;
-	midiMessages.push({ now, messages });
+	const bool queued = midiMessages.tryWrite([&](MessageQueueItem& item) {
+		item.whenToSend = now;
+		item.whatToSend = messages;
+	});
+	if (!queued) {
+		droppedMessages_.fetch_add(1, std::memory_order_relaxed);
+	}
+	return queued;
+}
+
+uint64_t MidiSendThread::droppedMessages() const noexcept
+{
+	return droppedMessages_.load(std::memory_order_relaxed);
 }
 
 void MidiSendThread::run()
@@ -42,15 +53,20 @@ void MidiSendThread::run()
 	// The problem is that the Audio thread is only running at e.g. 4 milliseconds clock, and that is about my current jitter - no surprise there.
 	while (!threadShouldExit()) {
 		try {
-			MessageQueueItem item;
-			while (midiMessages.try_pop(item) && !threadShouldExit()) {
+			bool sentAny = false;
+			while (midiMessages.tryRead([&](MessageQueueItem& item) {
 				// Wait until the time has come
 				while (std::chrono::high_resolution_clock::now() < item.whenToSend) {
+					juce::Thread::yield();
 				}
 				// Send the F8 MIDI Clock message to all devices registered
 				for (auto &out : f8_outputs) {
 					out->sendBlockOfMessagesFullSpeed(item.whatToSend);
 				}
+				sentAny = true;
+			}) && !threadShouldExit()) {}
+			if (!sentAny) {
+				juce::Thread::sleep(1);
 			}
 		} catch (std::exception &e) {
 			spdlog::error("Failed to send MIDI Clock: {}", e.what());

--- a/Client/Source/MidiSendThread.h
+++ b/Client/Source/MidiSendThread.h
@@ -3,18 +3,9 @@
 #include "JuceHeader.h"
 
 #include "MidiController.h"
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wextra-semi"
-#endif
-#include "tbb/concurrent_queue.h"
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+#include "BoundedSpscQueue.h"
 
 #include <chrono>
-#include <deque>
 
 
 class MidiSendThread : juce::Thread {
@@ -22,17 +13,18 @@ public:
 	MidiSendThread(std::vector<juce::MidiDeviceInfo> const outputs);
 	virtual ~MidiSendThread() override;
 
-	void enqueue(std::chrono::high_resolution_clock::duration fromNow, std::vector<MidiMessage> const &messages);
+	bool enqueue(std::chrono::high_resolution_clock::duration fromNow, std::vector<MidiMessage> const &messages);
+	uint64_t droppedMessages() const noexcept;
 
 	void run() override;
 
 private:
-	juce::CriticalSection lock_;
-
 	struct MessageQueueItem {
 		std::chrono::high_resolution_clock::time_point whenToSend;
 		std::vector<MidiMessage> whatToSend;
 	};
-	tbb::concurrent_queue<MessageQueueItem> midiMessages;
+	// MIDI clock remains timely by dropping new messages after 256 are pending.
+	BoundedSpscQueue<MessageQueueItem> midiMessages { 256 };
+	std::atomic<uint64_t> droppedMessages_ { 0 };
 	std::vector<std::shared_ptr<midikraft::SafeMidiOutput>> f8_outputs;
 };

--- a/Client/Source/RealtimeAudioFrames.h
+++ b/Client/Source/RealtimeAudioFrames.h
@@ -1,0 +1,39 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "BuffersConfig.h"
+#include "JuceHeader.h"
+#include "JammerNetzPackage.h"
+
+#include <array>
+#include <optional>
+
+constexpr int JAMMERNETZ_MAX_AUDIO_CHANNELS = 64;
+constexpr int JAMMERNETZ_MAX_CALLBACK_SAMPLES = 8192;
+
+struct TransmitAudioFrame {
+	int channels { 0 };
+	std::array<std::array<float, SAMPLE_BUFFER_SIZE>, JAMMERNETZ_MAX_AUDIO_CHANNELS> samples {};
+	std::optional<float> bpm;
+	std::optional<MidiSignal> midiSignal;
+};
+
+struct RemoteAudioFrame {
+	std::array<std::array<float, SAMPLE_BUFFER_SIZE>, 2> samples {};
+	double sourceTimestamp { 0.0 };
+	uint64 generation { 0 };
+};
+
+enum class RecordingTarget : uint8_t { local, master };
+
+struct RecordingAudioFrame {
+	RecordingTarget target { RecordingTarget::local };
+	int channels { 0 };
+	int samplesPerChannel { 0 };
+	std::array<std::array<float, JAMMERNETZ_MAX_CALLBACK_SAMPLES>, JAMMERNETZ_MAX_AUDIO_CHANNELS> samples {};
+};

--- a/Client/Source/RealtimeAudioFrames.h
+++ b/Client/Source/RealtimeAudioFrames.h
@@ -33,6 +33,7 @@ enum class RecordingTarget : uint8_t { local, master };
 
 struct RecordingAudioFrame {
 	RecordingTarget target { RecordingTarget::local };
+	uint64_t recordingGeneration { 0 };
 	int channels { 0 };
 	int samplesPerChannel { 0 };
 	std::array<std::array<float, JAMMERNETZ_MAX_CALLBACK_SAMPLES>, JAMMERNETZ_MAX_AUDIO_CHANNELS> samples {};

--- a/common/PacketStreamQueue.cpp
+++ b/common/PacketStreamQueue.cpp
@@ -105,6 +105,30 @@ bool PacketStreamQueue::try_pop(std::shared_ptr<JammerNetzAudioData> &element, b
 	}
 }
 
+void PacketStreamQueue::reset()
+{
+	std::shared_ptr<JammerNetzAudioData> packet;
+	while (packetQueue.try_pop(packet)) {}
+	currentlyInQueue_.clear();
+	lastPushedMessage_.store(0, std::memory_order_relaxed);
+	lastPoppedMessage_.store(0, std::memory_order_relaxed);
+	lastPoppedMessageData_.reset();
+	currentGap_.store(0, std::memory_order_relaxed);
+	runningMeanClockDelta_.Clear();
+	runningMeanJitter_.Clear();
+	qualityData_.tooLateOrDuplicate.store(0, std::memory_order_relaxed);
+	qualityData_.droppedPacketCounter.store(0, std::memory_order_relaxed);
+	qualityData_.outOfOrderPacketCounter.store(0, std::memory_order_relaxed);
+	qualityData_.duplicatePacketCounter.store(0, std::memory_order_relaxed);
+	qualityData_.dropsHealed.store(0, std::memory_order_relaxed);
+	qualityData_.packagesPushed.store(0, std::memory_order_relaxed);
+	qualityData_.packagesPopped.store(0, std::memory_order_relaxed);
+	qualityData_.maxLengthOfGap.store(0, std::memory_order_relaxed);
+	qualityData_.maxWrongOrderSpan.store(0, std::memory_order_relaxed);
+	qualityData_.jitterMeanMillis.store(0.0, std::memory_order_relaxed);
+	qualityData_.jitterSDMillis.store(0.0, std::memory_order_relaxed);
+}
+
 size_t PacketStreamQueue::size() const
 {
 	return packetQueue.size();

--- a/common/PacketStreamQueue.h
+++ b/common/PacketStreamQueue.h
@@ -59,6 +59,7 @@ public:
 
 	bool push(std::shared_ptr<JammerNetzAudioData> packet);
 	bool try_pop(std::shared_ptr<JammerNetzAudioData> &element, bool &outIsFillIn);
+	void reset();
 	size_t size() const;
 
 	std::string qualityStatement() const;

--- a/common/Recorder.cpp
+++ b/common/Recorder.cpp
@@ -26,6 +26,7 @@ Recorder::~Recorder()
 	{
 		ScopedLock lock(stateLock_);
 		recording_.store(false, std::memory_order_release);
+		recordingGeneration_.store(0, std::memory_order_release);
 		writeThread_.reset();
 	}
 	// Give it a second to flush and exit
@@ -35,6 +36,7 @@ Recorder::~Recorder()
 void Recorder::setRecording(bool recordOn)
 {
 	ScopedLock lock(stateLock_);
+	const bool wasRecording = writeThread_ != nullptr;
 	if (recordOn && writeThread_ == nullptr) {
 		if (updateChannelInfo(lastSampleRate_, lastChannelSetup_)) {
 			launchWriter();
@@ -42,12 +44,27 @@ void Recorder::setRecording(bool recordOn)
 	} else if (!recordOn && writeThread_ != nullptr) {
 		writeThread_.reset();
 	}
-	recording_.store(writeThread_ != nullptr, std::memory_order_release);
+	const bool isNowRecording = writeThread_ != nullptr;
+	if (isNowRecording && !wasRecording) {
+		++nextRecordingGeneration_;
+		if (nextRecordingGeneration_ == 0) {
+			++nextRecordingGeneration_;
+		}
+		recordingGeneration_.store(nextRecordingGeneration_, std::memory_order_release);
+	} else if (!isNowRecording) {
+		recordingGeneration_.store(0, std::memory_order_release);
+	}
+	recording_.store(isNowRecording, std::memory_order_release);
 }
 
 bool Recorder::isRecording() const
 {
 	return recording_.load(std::memory_order_acquire);
+}
+
+uint64_t Recorder::recordingGeneration() const noexcept
+{
+	return recordingGeneration_.load(std::memory_order_acquire);
 }
 
 RelativeTime Recorder::getElapsedTime() const
@@ -195,6 +212,7 @@ void Recorder::setDirectory(File &directory)
 	ScopedLock lock(stateLock_);
 	// Stop writing if any
 	recording_.store(false, std::memory_order_release);
+	recordingGeneration_.store(0, std::memory_order_release);
 	writeThread_.reset();
 	directory_ = directory;
 }

--- a/common/Recorder.cpp
+++ b/common/Recorder.cpp
@@ -25,6 +25,7 @@ Recorder::~Recorder()
 	// Stop writing, make sure to finalize file
 	{
 		ScopedLock lock(stateLock_);
+		recording_.store(false, std::memory_order_release);
 		writeThread_.reset();
 	}
 	// Give it a second to flush and exit
@@ -40,12 +41,12 @@ void Recorder::setRecording(bool recordOn)
 	} else if (!recordOn && writeThread_ != nullptr) {
 		writeThread_.reset();
 	}
+	recording_.store(writeThread_ != nullptr, std::memory_order_release);
 }
 
 bool Recorder::isRecording() const
 {
-	ScopedLock lock(stateLock_);
-	return writeThread_ != nullptr;
+	return recording_.load(std::memory_order_acquire);
 }
 
 RelativeTime Recorder::getElapsedTime() const
@@ -190,6 +191,7 @@ void Recorder::setDirectory(File &directory)
 {
 	ScopedLock lock(stateLock_);
 	// Stop writing if any
+	recording_.store(false, std::memory_order_release);
 	writeThread_.reset();
 	directory_ = directory;
 }

--- a/common/Recorder.h
+++ b/common/Recorder.h
@@ -25,6 +25,7 @@ public:
 
 	void setRecording(bool recordOn);
 	bool isRecording() const;
+	uint64_t recordingGeneration() const noexcept;
 
 	RelativeTime getElapsedTime() const;
 	String getFilename() const;
@@ -51,6 +52,8 @@ private:
 	std::unique_ptr<TimeSliceThread> thread_;
 	std::unique_ptr<AudioFormatWriter::ThreadedWriter> writeThread_;
 	std::atomic<bool> recording_ { false };
+	std::atomic<uint64_t> recordingGeneration_ { 0 };
+	uint64_t nextRecordingGeneration_ { 0 };
 
 	int lastSampleRate_;
 	JammerNetzChannelSetup lastChannelSetup_;

--- a/common/Recorder.h
+++ b/common/Recorder.h
@@ -10,6 +10,8 @@
 
 #include "JammerNetzPackage.h"
 
+#include <atomic>
+
 enum class RecordingType {
 	WAV,
 	FLAC,
@@ -48,6 +50,7 @@ private:
 	AudioFormatWriter *writer_;
 	std::unique_ptr<TimeSliceThread> thread_;
 	std::unique_ptr<AudioFormatWriter::ThreadedWriter> writeThread_;
+	std::atomic<bool> recording_ { false };
 
 	int lastSampleRate_;
 	JammerNetzChannelSetup lastChannelSetup_;


### PR DESCRIPTION
Stacked on #56. Implements Phase 3 of the audio-engine plan.\n\n- moves packet construction, pitch detection, encryption, and network sends to a bounded transmit worker\n- moves receive ordering, fill-in, MIDI scheduling, and session-meter preparation to a receive worker behind bounded queues\n- adds a bounded recording handoff and lock-free recording-state check\n- removes UI dispatch and unbounded diagnostic publication from the audio callback\n- adds deterministic overflow counters, callback timing metrics, reconnect reset semantics, and saturation/regression tests\n\nLocal validation:\n- JammerNetzCore Release source target compiles successfully\n- PacketStreamQueue compiles under /W4 /WX\n- JammerNetzCoreTest source compiles successfully\n- the exact full build reaches pre-existing local environment failures: the modified local JUCE checkout lacks AudioFormatWriterOptions, and Windows test discovery cannot locate a runtime DLL. Clean GitHub CI is the authoritative full matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved real-time audio transmission, reception, monitoring, and recording with smoother background processing.
  * Added support for audio buffering, rebuffering, playback recovery, MIDI timing, BPM updates, and level monitoring.
  * Added real-time performance statistics, including callback activity, dropped frames, queue usage, and recording metrics.
  * Improved handling of varying audio block sizes and channel configurations.

* **Bug Fixes**
  * Improved audio and session shutdown ordering.
  * Added reliable stream reset behavior and safer recording-state tracking.
  * Reduced busy-waiting and improved handling when audio or MIDI queues are full.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->