### PR TITLE
Bound playout latency after receive hiccups

### DIFF
--- a/Client/Source/AudioReceiveWorker.cpp
+++ b/Client/Source/AudioReceiveWorker.cpp
@@ -133,21 +133,42 @@ void AudioReceiveWorker::run()
 		drainInbound();
 		if (rebufferRequested_.exchange(false, std::memory_order_acq_rel)) {
 			streamStarted_.store(false, std::memory_order_release);
+			recoveringFromOverrun_ = false;
 		}
 
 		const auto minimum = minimumFrames_.load(std::memory_order_relaxed);
+		const auto maximum = maximumFrames_.load(std::memory_order_relaxed);
+		const auto combinedReadyFrames = [this]() {
+			return static_cast<uint64_t>(outputQueue_.size()) + static_cast<uint64_t>(packetQueue_.size());
+		};
+
+		// The prepared queue is the queue the audio callback actually drains. If
+		// the callback stalls, stop feeding it and discard old ordered packets
+		// until the prepared queue has played back to the configured minimum.
+		// This restores the bounded-latency behaviour of the original single
+		// queue without doing queue maintenance on the real-time thread.
+		if (combinedReadyFrames() > maximum) {
+			recoveringFromOverrun_ = true;
+		}
+		if (recoveringFromOverrun_) {
+			std::shared_ptr<JammerNetzAudioData> discardedPacket;
+			bool fillIn = false;
+			while (combinedReadyFrames() > minimum && packetQueue_.try_pop(discardedPacket, fillIn)) {
+				discarded_.fetch_add(1, std::memory_order_relaxed);
+			}
+			if (combinedReadyFrames() <= minimum) {
+				recoveringFromOverrun_ = false;
+			}
+		}
+
 		if (!streamStarted_.load(std::memory_order_acquire) && packetQueue_.size() >= minimum) {
 			streamStarted_.store(true, std::memory_order_release);
 		}
 
-		const auto maximum = maximumFrames_.load(std::memory_order_relaxed);
-		std::shared_ptr<JammerNetzAudioData> discardedPacket;
-		bool fillIn = false;
-		while (packetQueue_.size() > maximum && packetQueue_.try_pop(discardedPacket, fillIn)) {
-			discarded_.fetch_add(1, std::memory_order_relaxed);
-		}
-
-		const bool prepared = streamStarted_.load(std::memory_order_acquire) && prepareOneFrame();
+		const bool prepared = streamStarted_.load(std::memory_order_acquire)
+			&& !recoveringFromOverrun_
+			&& static_cast<uint64_t>(outputQueue_.size()) < maximum
+			&& prepareOneFrame();
 		if (!prepared) {
 			juce::Thread::sleep(1);
 		}
@@ -164,6 +185,7 @@ void AudioReceiveWorker::applyResetIfRequested()
 	while (inboundQueue_.tryRead([&packet](std::shared_ptr<JammerNetzAudioData>& queued) { packet = std::move(queued); })) {}
 	packetQueue_.reset();
 	streamStarted_.store(false, std::memory_order_release);
+	recoveringFromOverrun_ = false;
 	activeGeneration_.store(requested, std::memory_order_release);
 }
 

--- a/Client/Source/AudioReceiveWorker.h
+++ b/Client/Source/AudioReceiveWorker.h
@@ -66,5 +66,6 @@ private:
 	std::atomic<uint64_t> discarded_ { 0 };
 	std::atomic<uint64_t> inboundOverruns_ { 0 };
 	std::atomic<uint64_t> outputOverruns_ { 0 };
+	bool recoveringFromOverrun_ { false };
 	MidiSignal pendingMidiSignal_ { MidiSignal_None };
 };

--- a/Client/Source/BoundedSpscQueue.h
+++ b/Client/Source/BoundedSpscQueue.h
@@ -15,7 +15,10 @@
 template <typename Item>
 class BoundedSpscQueue {
 public:
-	explicit BoundedSpscQueue(int capacity) : fifo_(capacity), slots_(static_cast<size_t>(capacity)) {}
+	// AbstractFifo keeps one backing slot empty to distinguish full from empty,
+	// so allocate one extra slot to make this wrapper's capacity exact.
+	explicit BoundedSpscQueue(int capacity)
+		: fifo_(capacity + 1), slots_(static_cast<size_t>(capacity + 1)) {}
 
 	template <typename Writer>
 	bool tryWrite(Writer&& writer)

--- a/Client/Source/JammerNetzAudioEngineTests.cpp
+++ b/Client/Source/JammerNetzAudioEngineTests.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "JammerNetzAudioEngine.h"
+#include "AudioReceiveWorker.h"
 #include "BuffersConfig.h"
 #include "BoundedSpscQueue.h"
 #include "PacketStreamQueue.h"
@@ -22,6 +23,17 @@ JammerNetzChannelSetup monoLocalSetup()
 	JammerNetzChannelSetup setup(true);
 	setup.channels.emplace_back(JammerNetzChannelTarget::Mono);
 	return setup;
+}
+
+std::shared_ptr<JammerNetzAudioData> remotePacket(uint64 counter)
+{
+	auto audio = std::make_shared<juce::AudioBuffer<float>>(2, SAMPLE_BUFFER_SIZE);
+	JammerNetzChannelSetup setup(false, {
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Left),
+		JammerNetzSingleChannelSetup(JammerNetzChannelTarget::Right)
+	});
+	return std::make_shared<JammerNetzAudioData>(
+		counter, juce::Time::getMillisecondCounterHiRes(), setup, SAMPLE_RATE, 120.0f, MidiSignal_None, audio, nullptr);
 }
 
 TEST(JammerNetzSessionTest, ConstructionHasNoExternalSideEffects)
@@ -205,6 +217,36 @@ TEST(JammerNetzAudioEngineTest, BoundsReceiveBurstsBeforeTheWorkerStarts)
 	const auto stats = engine.getRealtimeWorkerStats();
 	EXPECT_EQ(stats.receiveQueueOverruns, 88u);
 	EXPECT_EQ(stats.receiveFramesDiscarded, 88u);
+}
+
+TEST(AudioReceiveWorkerTest, CapsPreparedPlayoutAfterAConsumerHiccup)
+{
+	JammerNetzSession session;
+	AudioReceiveWorker worker(session);
+	worker.setPlayoutRange(1, 4);
+	worker.start();
+
+	// Feed at approximately the normal network cadence while deliberately not
+	// consuming. The old worker filled its separate prepared queue indefinitely
+	// because the configured maximum was enforced only on the ordering queue.
+	for (uint64 counter = 1; counter <= 12; ++counter) {
+		worker.enqueue(remotePacket(counter));
+		juce::Thread::sleep(4);
+	}
+	for (int attempt = 0; attempt < 100 && worker.discardedFrames() == 0; ++attempt) {
+		juce::Thread::sleep(2);
+	}
+
+	EXPECT_LE(worker.readyFrames(), 4);
+	EXPECT_GT(worker.discardedFrames(), 0u);
+
+	RemoteAudioFrame frame;
+	while (worker.readyFrames() > 1) {
+		EXPECT_TRUE(worker.tryPop(frame));
+	}
+	juce::Thread::sleep(10);
+	EXPECT_LE(worker.readyFrames(), 1);
+	worker.shutdown();
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- cap the combined prepared and ordered receive backlog at the configured playout maximum
- recover from consumer stalls by discarding stale ordered packets until prepared audio drains to the jitter target
- make bounded SPSC queue capacity exact despite JUCE AbstractFifo reserving one slot
- add a regression test that simulates a consumer hiccup and verifies bounded recovery

## Regression
This restores behavior present before the Phase 3 receive-worker split. The earlier single receive queue was trimmed whenever it exceeded the configured maximum; after the split, trimming watched only the upstream ordering queue while PlayQ reported the separate prepared queue, allowing latency to remain inflated after a hiccup.

## Validation
- cmake --build builds --parallel
- ctest --test-dir builds -C Debug --output-on-failure (21/21 passed)