### PR TITLE
Add Apple Silicon AUv2 CI build

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -49,6 +49,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - name: Require an Apple Silicon runner
+      run: test "$(uname -m)" = "arm64"
+
     - name: Disable git automatic line ending conversion
       run: git config --global core.autocrlf false
 
@@ -70,10 +73,21 @@ jobs:
 
     - name: Build with CMake
       run: |
-        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_RPATH_USE_LINK_PATH="ON" -DJAMMERNETZ_ENABLE_LTO=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-        cmake --build build --target JammerNetzPlugin_VST3 JammerNetzPluginTest --parallel
+        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH="ON" -DJAMMERNETZ_ENABLE_LTO=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        cmake --build build --target JammerNetzPlugin_VST3 JammerNetzPlugin_AU JammerNetzPluginTest --parallel
         ctest --test-dir build -R JammerNetzPluginTest --output-on-failure
         cmake --build build --target package --parallel
+
+    - name: Validate macOS plug-ins
+      run: |
+        vst3="build/Plugin/JammerNetzPlugin_artefacts/RelWithDebInfo/VST3/JammerNetz.vst3"
+        component="build/Plugin/JammerNetzPlugin_artefacts/RelWithDebInfo/AU/JammerNetz.component"
+        test "$(lipo -archs "$vst3/Contents/MacOS/JammerNetz")" = "arm64"
+        test "$(lipo -archs "$component/Contents/MacOS/JammerNetz")" = "arm64"
+        mkdir -p "$HOME/Library/Audio/Plug-Ins/Components"
+        ditto "$component" "$HOME/Library/Audio/Plug-Ins/Components/JammerNetz.component"
+        killall -9 AudioComponentRegistrar || true
+        auval -v aufx JnP4 JmNz
 
     - name: Upload Mac Installer
       uses: actions/upload-artifact@v4
@@ -86,3 +100,9 @@ jobs:
       with:
         name: JammerNetz-macOS-VST3
         path: build/Plugin/JammerNetzPlugin_artefacts/RelWithDebInfo/VST3/JammerNetz.vst3
+
+    - name: Upload macOS AUv2
+      uses: actions/upload-artifact@v4
+      with:
+        name: JammerNetz-macOS-AUv2
+        path: build/Plugin/JammerNetzPlugin_artefacts/RelWithDebInfo/AU/JammerNetz.component

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,47 @@
 # Repository Agent Notes
 
-- After code changes, run `cmake --build builds --parallel` before finishing to catch compiler warnings/errors.
+## Christof's Windows development machine
 
+These paths and choices describe the established setup on this computer. Prefer them over probing for or installing another toolchain. Use repository-relative paths in commands so the instructions also work from another JammerNetz checkout.
+
+- CMake: `C:\Program Files\CMake\bin\cmake.exe` (currently 3.31.6 and normally available as `cmake`).
+- Generator: prefer 64-bit Visual Studio 2022, exactly `-G "Visual Studio 17 2022" -A x64`. Do not replace it with Ninja unless the task specifically requires Ninja.
+- Visual Studio: Community 2022 at `C:\Program Files\Microsoft Visual Studio\2022\Community`, with the Desktop development with C++ workload. The generated solution is `builds\JammerNetz.sln`.
+- Python: use `C:\python\Python314\python.exe` (currently Python 3.14.3). A plain `python` is not on `PATH`, so pass `-DPython_EXECUTABLE=C:/python/Python314/python.exe` when configuring instead of relying on discovery.
+- FlatBuffers compiler: Windows multi-configuration builds select a configuration-matching executable. A Debug build therefore requires `third_party\flatbuffers\Builds\Debug\flatc.exe`; the Release executable is not a substitute for that path.
+
+From a repository root, prepare `flatc` for Debug builds with:
+
+```bat
+cmake -S third_party\flatbuffers -B third_party\flatbuffers\Builds -G "Visual Studio 17 2022" -A x64
+cmake --build third_party\flatbuffers\Builds --config Debug --parallel --target flatc
+```
+
+Configure the main Debug-capable build tree with:
+
+```bat
+cmake -S . -B builds -G "Visual Studio 17 2022" -A x64 -DPython_EXECUTABLE=C:/python/Python314/python.exe -DBUILD_JAMMERNETZ_CLIENT=ON -DBUILD_JAMMERNETZ_SERVER=ON -DBUILD_JAMMERNETZ_PLUGIN=ON
+```
+
+The Visual Studio generator is multi-configuration: use `--config Debug` when selecting targets and `ctest -C Debug` when running tests. For the plug-in/server workflow, prefer the checked-in helper:
+
+```bat
+Plugin\windows-debug.cmd build
+Plugin\windows-debug.cmd server
+Plugin\windows-debug.cmd ableton
+Plugin\windows-debug.cmd vs
+```
+
+The helper locates Visual Studio through `vswhere`, adds the installed x64 MSVC Debug CRT and the build's `tbb12_debug.dll` directory to `PATH`, and builds Debug TBB if necessary. Launch Ableton or Visual Studio through the helper when loading Debug plug-ins; launching them normally can make the plug-in fail to load because Debug runtime DLLs are not globally installed on `PATH`.
+
+### Agent Git quirks on this machine
+
+- Agent processes may run under a different Windows account from the checkout owner. If Git reports dubious ownership, use a command-local override such as `git -c safe.directory=D:/Development/github/JammerNetz-OS status`; do not silently change the user's global Git configuration. Adjust the path for another checkout or worktree.
+- `pre-commit` 4.6.2 is installed under Python 3.14 and the shared `.git\hooks\pre-commit` is generated for `C:\python\Python314\python.exe`. `C:\python\Python314\Scripts` is not on `PATH`, so invoke it as `C:\python\Python314\python.exe -m pre_commit`. If the hook ever points to an obsolete interpreter again, repair it with `C:\python\Python314\python.exe -m pre_commit install` rather than bypassing it.
+
+Do not commit machine-local presets, secrets, Ableton paths, generated build trees, or copied plug-in binaries. In particular, `CMakeUserPresets.json` is local historical state and should not be treated as the canonical setup.
+
+## Required validation
+
+- After code changes, run `cmake --build builds --parallel` before finishing to catch compiler warnings/errors.
+- For Debug-only work, additionally build the relevant targets with `--config Debug` and run tests with `ctest --test-dir builds -C Debug --output-on-failure`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 OPTION(BUILD_JAMMERNETZ_CLIENT "Option to turn off the client build" ON)
 OPTION(BUILD_JAMMERNETZ_SERVER "Build the server and bundle it with the standalone client" ON)
-OPTION(BUILD_JAMMERNETZ_PLUGIN "Build the JammerNetz VST3 plug-in adapter" ${BUILD_JAMMERNETZ_CLIENT})
+OPTION(BUILD_JAMMERNETZ_PLUGIN "Build the JammerNetz audio plug-in adapters" ${BUILD_JAMMERNETZ_CLIENT})
 OPTION(JAMMERNETZ_ENABLE_LTO "Enable JUCE LTO flags (better runtime performance, slower links)" OFF)
 
 if(BUILD_JAMMERNETZ_PLUGIN AND NOT BUILD_JAMMERNETZ_CLIENT)

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -6,12 +6,17 @@
 
 project("JammerNetzPlugin" VERSION 2.3.0)
 
+set(JAMMERNETZ_PLUGIN_FORMATS VST3)
+if(APPLE)
+	list(APPEND JAMMERNETZ_PLUGIN_FORMATS AU)
+endif()
+
 juce_add_plugin(JammerNetzPlugin
 	COMPANY_NAME "Christof Ruch Beratungs UG"
 	BUNDLE_ID "com.christofmuc.jammernetz.plugin"
 	PLUGIN_MANUFACTURER_CODE JmNz
 	PLUGIN_CODE JnP4
-	FORMATS VST3
+	FORMATS ${JAMMERNETZ_PLUGIN_FORMATS}
 	PRODUCT_NAME "JammerNetz"
 	DESCRIPTION "Low-latency JammerNetz send and remote return"
 	IS_SYNTH FALSE

--- a/Plugin/README.md
+++ b/Plugin/README.md
@@ -1,4 +1,4 @@
-# JammerNetz VST3 plug-in
+# JammerNetz audio plug-ins
 
 The plug-in is a stereo effect adapter for the same audio engine used by the
 standalone client. Insert it on the stereo track or bus that should be sent to
@@ -7,7 +7,7 @@ keeps the host input audible by default.
 
 The first version intentionally has a narrow host contract:
 
-- VST3 format and stereo buses only.
+- VST3 on Windows and macOS, plus AUv2 on macOS; stereo buses only.
 - The host project must run at 48 kHz.
 - Only one plug-in instance can own an active network session in a host process.
 - Connection is explicit; scanning, construction, state restore, and opening the
@@ -30,6 +30,17 @@ Build the plug-in together with the client targets:
 cmake -S . -B builds -DBUILD_JAMMERNETZ_CLIENT=ON -DBUILD_JAMMERNETZ_PLUGIN=ON
 cmake --build builds --config RelWithDebInfo --target JammerNetzPlugin_VST3
 ```
+
+On macOS, build the AUv2 component as an additional wrapper over the same
+processor implementation:
+
+```sh
+cmake --build builds --config RelWithDebInfo --target JammerNetzPlugin_AU
+```
+
+VST3 remains the recommended format for Ableton Live projects that may move
+between Windows and macOS. AUv2 is provided for native macOS workflows and
+hosts such as Logic Pro, MainStage, and GarageBand.
 
 ## Windows Debug workflow
 

--- a/docs/audio-engine-refactoring-plan.md
+++ b/docs/audio-engine-refactoring-plan.md
@@ -266,6 +266,41 @@ Add a JUCE audio-effect plug-in as a second adapter over the completed engine.
 - Plug-in scanning, project restoration, bypass, editor closure, and shutdown are safe.
 - The plug-in does not weaken the real-time guarantees established in Phase 3.
 
+## Phase 5: macOS AUv2 adapter
+
+Build an Audio Unit v2 wrapper over the existing plug-in processor without
+changing its audio or session behavior.
+
+- Keep VST3 as the primary Ableton Live and cross-platform format.
+- Build AUv2 only on macOS and distribute it as `JammerNetz.component`.
+- Target Apple Silicon explicitly; Intel and Universal 2 artifacts are outside
+  the current support scope.
+- Run the shared processor tests and Apple's `auval` wrapper validation in CI.
+- Verify that both macOS plug-in binaries contain only the intended `arm64`
+  architecture.
+- Upload VST3 and AUv2 as separate CI artifacts.
+
+### Phase 5 completion criteria
+
+- The macOS CI build produces passing Apple Silicon VST3 and AUv2 artifacts.
+- The AUv2 component passes `auval` without starting a network session.
+- Windows and Linux builds remain unchanged by the additional Apple-only
+  format.
+
+## Phase 6: macOS distribution signing
+
+Prepare the standalone application, installer, VST3 bundle, and AUv2 component
+for distribution to other Mac users.
+
+- Sign all distributed executable code with the project's Developer ID.
+- Enable the hardened runtime and apply only the entitlements required by the
+  application and plug-ins.
+- Notarize the final installer or disk image and staple the resulting ticket.
+- Keep signing identities and notarization credentials in protected CI secrets;
+  never store them in the repository or ordinary build artifacts.
+- Test installation and plug-in discovery on a clean Apple Silicon Mac.
+- Treat unsigned CI artifacts as development outputs, not distributable builds.
+
 ## Deferred work
 
 The following are intentionally outside this plan:


### PR DESCRIPTION
## Summary
- build an AUv2 component alongside VST3 on macOS only
- make the macOS CI contract explicitly Apple Silicon (rm64, deployment target macOS 11)
- validate both plug-in binary architectures and run Apple's uval against the AU component
- upload VST3 and AUv2 as separate CI artifacts
- document VST3 as the Ableton/cross-platform default and reserve Developer ID signing and notarization for Phase 6

## Stack
This PR is stacked on the playout queue recovery PR.

## Validation
- cmake --build builds --parallel`n- ctest --test-dir builds -C Debug --output-on-failure (21/21 passed on Windows)
- macOS ARM64 AU build and uval run in CI